### PR TITLE
vuln-fix: Partial Path Traversal Vulnerability

### DIFF
--- a/src/main/java/io/jenkins/plugins/signpath/Common/TemporaryFile.java
+++ b/src/main/java/io/jenkins/plugins/signpath/Common/TemporaryFile.java
@@ -31,7 +31,7 @@ public class TemporaryFile implements Closeable {
         temporaryDirectory = Files.createTempDirectory("SignPathJenkinsPluginTemp").toFile();
         File newTemporaryFile = new File(temporaryDirectory, name);
 
-        if(!newTemporaryFile.getCanonicalPath().startsWith(temporaryDirectory.getCanonicalPath()))
+        if(!newTemporaryFile.getCanonicalFile().toPath().startsWith(temporaryDirectory.getCanonicalFile().toPath()))
             throw new IllegalAccessError("Navigating to parent is not allowed.");
 
         Path fileNamePath = Paths.get(newTemporaryFile.getCanonicalPath()).getFileName();


### PR DESCRIPTION
This fixes a partial path traversal vulnerability.

Replaces `dir.getCanonicalPath().startsWith(parent.getCanonicalPath())`, which is vulnerable to partial path traversal attacks, with the more secure `dir.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath())`.

To demonstrate this vulnerability, consider `"/usr/outnot".startsWith("/usr/out")`. The check is bypassed although `/outnot` is not under the `/out` directory. It's important to understand that the terminating slash may be removed when using various `String` representations of the `File` object. For example, on Linux, `println(new File("/var"))` will print `/var`, but `println(new File("/var", "/")` will print `/var/`; however, `println(new File("/var", "/").getCanonicalPath())` will print `/var`.

Weakness: CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal') Severity: Medium
CVSSS: 6.1
Detection: CodeQL & OpenRewrite (https://public.moderne.io/recipes/org.openrewrite.java.security.PartialPathTraversalVulnerability)

Reported-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>
Signed-off-by: Jonathan Leitschuh <Jonathan.Leitschuh@gmail.com>

Bug-tracker: https://github.com/JLLeitschuh/security-research/issues/13

Co-authored-by: Moderne <team@moderne.io>

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
