### PR TITLE
Rename CI User Token to API Token. Version updated to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ On SignPath.io:
 
 1. Add a Trusted Build System on SignPath and copy the generated **Trusted Build System Token**
 2. Link the Trusted Build System to all projects that are build with it
-3. Add one or more CI users (e.g. one per team) and copy the generated **CI User Token** (API Token)
+3. Add one or more CI users (e.g. one per team) and copy the generated **API Token**
 
 On Jenkins:
 
 1. Store the **Trusted Build System Token** in a System Credential (Under Manage Jenkins / Manage Credentials)
-2. Store the CI User Token(s) in a System Credential so that it is available to the build pipelines of the respective projects
+2. Store the API Token(s) in a System Credential so that it is available to the build pipelines of the respective projects
 
 _Note: Currently, the SignPath plugin requires you to use **git** as your source control system. The git repository origin information is extracted and included in the signing request._
 
@@ -53,7 +53,7 @@ Include the `submitSigningRequest` and optionally, the `getSignedArtifact` steps
 stage('Sign with SignPath') {
   steps {
     submitSigningRequest( 
-      ciUserTokenCredentialId: "${CI_USER_TOKEN_CREDENTIAL_ID}", 
+      apiTokenCredentialId: "${API_TOKEN_CREDENTIAL_ID}", 
       trustedBuildSystemTokenCredentialId: "${TRUSTED_BUILD_SYSTEM_TOKEN_CREDENTIAL_ID}", 
       organizationId: "${ORGANIZATION_ID}",
       projectSlug: "${PROJECT_SLUG}",
@@ -73,7 +73,7 @@ stage('Sign with SignPath') {
   steps {
     script {
       signingRequestId = submitSigningRequest( 
-        ciUserTokenCredentialId: "${CI_USER_TOKEN_CREDENTIAL_ID}", 
+        apiTokenCredentialId: "${API_TOKEN_CREDENTIAL_ID}", 
         trustedBuildSystemTokenCredentialId: "${TRUSTED_BUILD_SYSTEM_TOKEN_CREDENTIAL_ID}",
         organizationId: "${ORGANIZATION_ID}",
         projectSlug: "${PROJECT_SLUG}",
@@ -92,7 +92,7 @@ stage('Download Signed Artifact') {
   }
   steps{
     getSignedArtifact( 
-      ciUserToken: "${CI_USER_TOKEN}", 
+      apiToken: "${API_TOKEN}", 
       organizationId: "${ORGANIZATION_ID}",
       signingRequestId: "${signingRequestId}",
       outputArtifactPath: "build-output/my-artifact.exe"
@@ -107,7 +107,7 @@ stage('Download Signed Artifact') {
 | Parameter                                             |      |
 | ----------------------------------------------------- | ---- |
 | `apiUrl`                                              | (optional) The API endpoint of SignPath. Defaults to `https://app.signpath.io/api`
-| `ciUserTokenCredentialId`                             | The ID of the credential containing the **CI User Token**
+| `apiTokenCredentialId`                                | The ID of the credential containing the **API Token**
 | `trustedBuildSytemTokenCredentialId`                  | The ID of the credential containing the **Trusted Build System Token**
 | `organizationId`, `projectSlug`, `signingPolicySlug`  | Specify which organization, project and signing policy to use for signing. See the [official documentation](https://about.signpath.io/documentation/build-system-integration)
 | `inputArtifactPath`                                   | The relative path of the artifact to be signed

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
-        <revision>1.1.0</revision>
+        <revision>2.0.0</revision>
         <changelist></changelist>
         <jenkins.version>2.359</jenkins.version>
         <java.level>11</java.level>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>io.signpath.javaclient</groupId>
             <artifactId>api-client</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
+++ b/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
@@ -51,7 +51,7 @@ public class SignPathClientFacade implements SignPathFacade {
             TemporaryFile outputArtifact = new TemporaryFile();
             
             String requestId = this.client.submitSigningRequestAndWaitForSignedArtifact(
-                    credentials.getCiUserToken().getPlainText(),
+                    credentials.getApiToken().getPlainText(),
                     credentials.getTrustedBuildSystemToken().getPlainText(),
                     submitModel.getOrganizationId().toString(),
                     submitModel.getArtifact().getFile(),
@@ -77,7 +77,7 @@ public class SignPathClientFacade implements SignPathFacade {
     public UUID submitSigningRequestAsync(SigningRequestModel submitModel) throws SignPathFacadeCallException {
         
         String requestId = this.client.submitSigningRequest(
-                credentials.getCiUserToken().getPlainText(),
+                credentials.getApiToken().getPlainText(),
                 credentials.getTrustedBuildSystemToken().getPlainText(),
                 submitModel.getOrganizationId().toString(),
                 submitModel.getArtifact().getFile(),
@@ -95,7 +95,7 @@ public class SignPathClientFacade implements SignPathFacade {
         
         try {
             SigningRequest request = client.getSigningRequestWaitForFinalStatus(
-                credentials.getCiUserToken().getPlainText(),
+                credentials.getApiToken().getPlainText(),
                 credentials.getTrustedBuildSystemToken().getPlainText(),
                 organizationId.toString(),
                 signingRequestID.toString());
@@ -105,7 +105,7 @@ public class SignPathClientFacade implements SignPathFacade {
             }
 
             client.downloadSignedArtifact(
-                    credentials.getCiUserToken().getPlainText(),
+                    credentials.getApiToken().getPlainText(),
                     credentials.getTrustedBuildSystemToken().getPlainText(),
                     organizationId.toString(),
                     signingRequestID.toString(),

--- a/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathCredentials.java
+++ b/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathCredentials.java
@@ -8,16 +8,16 @@ import hudson.util.Secret;
  * @see SignPathFacade
  */
 public class SignPathCredentials {
-    private final Secret ciUserToken;
+    private final Secret apiToken;
     private final Secret trustedBuildSystemToken;
 
-    public SignPathCredentials(Secret ciUserToken, Secret trustedBuildSystemToken) {
-        this.ciUserToken = ciUserToken;
+    public SignPathCredentials(Secret apiToken, Secret trustedBuildSystemToken) {
+        this.apiToken = apiToken;
         this.trustedBuildSystemToken = trustedBuildSystemToken;
     }
     
-    public Secret getCiUserToken() {
-        return ciUserToken;
+    public Secret getApiToken() {
+        return apiToken;
     }
     
     public Secret getTrustedBuildSystemToken() {
@@ -25,6 +25,6 @@ public class SignPathCredentials {
     }
 
     public Secret toCredentialString() {
-        return Secret.fromString(String.format("%s:%s", ciUserToken.getPlainText(), trustedBuildSystemToken.getPlainText()));
+        return Secret.fromString(String.format("%s:%s", apiToken.getPlainText(), trustedBuildSystemToken.getPlainText()));
     }
 }

--- a/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStep.java
+++ b/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStep.java
@@ -42,7 +42,7 @@ public class GetSignedArtifactStep extends SignPathStepBase {
                 ensureValidUUID(getOrganizationId(), "organizationId"),
                 ensureValidUUID(getSigningRequestId(), "signingRequestId"),
                 ensureNotNull(getTrustedBuildSystemTokenCredentialId(), "trustedBuildSystemTokenCredentialId"),
-                ensureNotNull(getCiUserTokenCredentialId(), "ciUserTokenCredentialId"),
+                ensureNotNull(getApiTokenCredentialId(), "apiTokenCredentialId"),
                 ensureNotNull(getOutputArtifactPath(), "outputArtifactPath"));
 
         ApiConfiguration apiConfiguration = getAndValidateApiConfiguration();

--- a/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStepExecution.java
@@ -54,8 +54,8 @@ public class GetSignedArtifactStepExecution extends SynchronousNonBlockingStepEx
 
         try {
             Secret trustedBuildSystemToken = secretRetriever.retrieveSecret(input.getTrustedBuildSystemTokenCredentialId());
-            Secret ciUserToken = secretRetriever.retrieveSecret(input.getCiUserTokenCredentialId());
-            SignPathCredentials credentials = new SignPathCredentials(ciUserToken, trustedBuildSystemToken);
+            Secret apiToken = secretRetriever.retrieveSecret(input.getApiTokenCredentialId());
+            SignPathCredentials credentials = new SignPathCredentials(apiToken, trustedBuildSystemToken);
             SignPathFacade signPathFacade = signPathFacadeFactory.create(credentials);
             try (TemporaryFile signedArtifact = signPathFacade.getSignedArtifact(input.getOrganizationId(), input.getSigningRequestId())) {
                 artifactFileManager.storeArtifact(signedArtifact, input.getOutputArtifactPath());

--- a/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStepInput.java
+++ b/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStepInput.java
@@ -14,14 +14,14 @@ public class GetSignedArtifactStepInput implements Serializable {
     private final UUID organizationId;
     private final UUID signingRequestId;
     private final String trustedBuildSystemTokenCredentialId;
-    private final String ciUserTokenCredentialId;
+    private final String apiTokenCredentialId;
     private final String outputArtifactPath;
 
-    public GetSignedArtifactStepInput(UUID organizationId, UUID signingRequestId, String trustedBuildSystemTokenCredentialId, String ciUserTokenCredentialId, String outputArtifactPath) {
+    public GetSignedArtifactStepInput(UUID organizationId, UUID signingRequestId, String trustedBuildSystemTokenCredentialId, String apiTokenCredentialId, String outputArtifactPath) {
         this.organizationId = organizationId;
         this.signingRequestId = signingRequestId;
         this.trustedBuildSystemTokenCredentialId = trustedBuildSystemTokenCredentialId;
-        this.ciUserTokenCredentialId = ciUserTokenCredentialId;
+        this.apiTokenCredentialId = apiTokenCredentialId;
         this.outputArtifactPath = outputArtifactPath;
     }
 
@@ -37,8 +37,8 @@ public class GetSignedArtifactStepInput implements Serializable {
         return trustedBuildSystemTokenCredentialId;
     }
 
-    public String getCiUserTokenCredentialId() {
-        return ciUserTokenCredentialId;
+    public String getApiTokenCredentialId() {
+        return apiTokenCredentialId;
     }
 
     public String getOutputArtifactPath() {

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
@@ -35,7 +35,7 @@ public abstract class SignPathStepBase extends Step {
     private int waitForPowerShellTimeoutInSeconds = (int) TimeUnit.MINUTES.toSeconds(30);
 
     private String trustedBuildSystemTokenCredentialId = "SignPath.TrustedBuildSystemToken";
-    private String ciUserTokenCredentialId = "SignPath.CIUserToken";
+    private String apiTokenCredentialId = "SignPath.ApiToken";
 
     public String getApiUrl() {
         return apiUrl;
@@ -45,8 +45,8 @@ public abstract class SignPathStepBase extends Step {
         return trustedBuildSystemTokenCredentialId;
     }
 
-    public String getCiUserTokenCredentialId() {
-        return ciUserTokenCredentialId;
+    public String getApiTokenCredentialId() {
+        return apiTokenCredentialId;
     }
 
     public int getServiceUnavailableTimeoutInSeconds() {
@@ -80,8 +80,8 @@ public abstract class SignPathStepBase extends Step {
     }
 
     @DataBoundSetter
-    public void setCiUserTokenCredentialId(String ciUserTokenCredentialId) {
-        this.ciUserTokenCredentialId = ciUserTokenCredentialId;
+    public void setApiTokenCredentialId(String apiTokenCredentialId) {
+        this.apiTokenCredentialId = apiTokenCredentialId;
     }
 
     @DataBoundSetter

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
@@ -50,7 +50,7 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
         SubmitSigningRequestStepInput input = new SubmitSigningRequestStepInput(
                 ensureValidUUID(getOrganizationId(), "organizationId"),
                 ensureNotNull(getTrustedBuildSystemTokenCredentialId(), "trustedBuildSystemTokenCredentialId"),
-                ensureNotNull(getCiUserTokenCredentialId(), "ciUserTokenCredentialId"),
+                ensureNotNull(getApiTokenCredentialId(), "apiTokenCredentialId"),
                 ensureNotNull(getProjectSlug(), "projectSlug"),
                 getArtifactConfigurationSlug(),
                 ensureNotNull(getSigningPolicySlug(), "signingPolicySlug"),

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepExecution.java
@@ -60,8 +60,8 @@ public class SubmitSigningRequestStepExecution extends SynchronousNonBlockingSte
 
         try {
             Secret trustedBuildSystemToken = secretRetriever.retrieveSecret(input.getTrustedBuildSystemTokenCredentialId());
-            Secret ciUserToken = secretRetriever.retrieveSecret(input.getCiUserTokenCredentialId());
-            SignPathCredentials credentials = new SignPathCredentials(ciUserToken, trustedBuildSystemToken);
+            Secret apiToken = secretRetriever.retrieveSecret(input.getApiTokenCredentialId());
+            SignPathCredentials credentials = new SignPathCredentials(apiToken, trustedBuildSystemToken);
             SignPathFacade signPathFacade = signPathFacadeFactory.create(credentials);
             try(SigningRequestOriginModel originModel = originRetriever.retrieveOrigin()) {
                 try (TemporaryFile unsignedArtifact = artifactFileManager.retrieveArtifact(input.getInputArtifactPath())) {

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepInput.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepInput.java
@@ -13,7 +13,7 @@ public class SubmitSigningRequestStepInput implements Serializable {
 
     private final UUID organizationId;
     private final String trustedBuildSystemTokenCredentialId;
-    private final String ciUserTokenCredentialId;
+    private final String apiTokenCredentialId;
     private final String projectSlug;
     private final String artifactConfigurationSlug;
     private final String signingPolicySlug;
@@ -24,7 +24,7 @@ public class SubmitSigningRequestStepInput implements Serializable {
 
     public SubmitSigningRequestStepInput(UUID organizationId,
                                          String trustedBuildSystemTokenCredentialId,
-                                         String ciUserTokenCredentialId,
+                                         String apiTokenCredentialId,
                                          String projectSlug,
                                          String artifactConfigurationSlug,
                                          String signingPolicySlug,
@@ -34,7 +34,7 @@ public class SubmitSigningRequestStepInput implements Serializable {
                                          boolean waitForCompletion) {
         this.organizationId = organizationId;
         this.trustedBuildSystemTokenCredentialId = trustedBuildSystemTokenCredentialId;
-        this.ciUserTokenCredentialId = ciUserTokenCredentialId;
+        this.apiTokenCredentialId = apiTokenCredentialId;
         this.projectSlug = projectSlug;
         this.artifactConfigurationSlug = artifactConfigurationSlug;
         this.signingPolicySlug = signingPolicySlug;
@@ -56,8 +56,8 @@ public class SubmitSigningRequestStepInput implements Serializable {
         return trustedBuildSystemTokenCredentialId;
     }
 
-    public String getCiUserTokenCredentialId() {
-        return ciUserTokenCredentialId;
+    public String getApiTokenCredentialId() {
+        return apiTokenCredentialId;
     }
 
     public String getInputArtifactPath() {

--- a/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
@@ -41,15 +41,15 @@ public class GetSignedArtifactStepEndToEndTest {
         byte[] signedArtifactBytes = Some.bytes();
         String trustedBuildSystemTokenCredentialId = Some.stringNonEmpty();
         String trustedBuildSystemToken = Some.stringNonEmpty();
-        String ciUserTokenCredentialId = Some.stringNonEmpty();
-        String ciUserToken = Some.stringNonEmpty();
+        String apiTokenCredentialId = Some.stringNonEmpty();
+        String apiToken = Some.stringNonEmpty();
         String organizationId = Some.uuid().toString();
         String signingRequestId = Some.uuid().toString();
 
         CredentialsStore credentialStore = CredentialStoreUtils.getCredentialStore(j.jenkins);
         assert credentialStore != null;
         CredentialStoreUtils.addCredentials(credentialStore, CredentialsScope.SYSTEM, trustedBuildSystemTokenCredentialId, trustedBuildSystemToken);
-        CredentialStoreUtils.addCredentials(credentialStore, CredentialsScope.SYSTEM, ciUserTokenCredentialId, ciUserToken);
+        CredentialStoreUtils.addCredentials(credentialStore, CredentialsScope.SYSTEM, apiTokenCredentialId, apiToken);
 
         String apiUrl = getMockUrl();
         
@@ -63,7 +63,7 @@ public class GetSignedArtifactStepEndToEndTest {
                         .withStatus(200)
                         .withBody(signedArtifactBytes)));
 
-        WorkflowJob workflowJob = createWorkflowJob(apiUrl, trustedBuildSystemTokenCredentialId, ciUserTokenCredentialId, organizationId, signingRequestId);
+        WorkflowJob workflowJob = createWorkflowJob(apiUrl, trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, signingRequestId);
 
         String remoteUrl = Some.url();
         BuildData buildData = new BuildData(Some.stringNonEmpty());
@@ -85,7 +85,7 @@ public class GetSignedArtifactStepEndToEndTest {
         assertArrayEquals(signedArtifactBytes, signedArtifactContent);
 
         wireMockRule.verify(getRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId))
-                .withHeader("Authorization", equalTo("Bearer " + ciUserToken + ":" + trustedBuildSystemToken)));
+                .withHeader("Authorization", equalTo("Bearer " + apiToken + ":" + trustedBuildSystemToken)));
     }
 
     @Theory
@@ -108,14 +108,14 @@ public class GetSignedArtifactStepEndToEndTest {
 
     private WorkflowJob createWorkflowJob(String apiUrl,
                                           String trustedBuildSystemTokenCredentialId,
-                                          String ciUserTokenCredentialId,
+                                          String apiTokenCredentialId,
                                           String organizationId,
                                           String signingRequestId) throws IOException {
         return j.createWorkflow("SignPath",
                 "getSignedArtifact( apiUrl: '" + apiUrl + "', " +
                         "outputArtifactPath: 'signed.exe', " +
                         "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
-                        "ciUserTokenCredentialId: '" + ciUserTokenCredentialId + "'," +
+                        "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
                         "signingRequestId: '" + signingRequestId + "'," +
                         "serviceUnavailableTimeoutInSeconds: 10," +

--- a/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
@@ -49,8 +49,8 @@ public class SubmitSigningRequestStepEndToEndTest {
         String trustedBuildSystemTokenCredentialId = Some.stringNonEmpty();
         String trustedBuildSystemToken = Some.stringNonEmpty();
         String unsignedArtifactString = Some.stringNonEmpty();
-        String ciUserTokenCredentialId = Some.stringNonEmpty();
-        String ciUserToken = Some.stringNonEmpty();
+        String apiTokenCredentialId = Some.stringNonEmpty();
+        String apiToken = Some.stringNonEmpty();
         String projectSlug = Some.stringNonEmpty();
         String signingPolicySlug = Some.stringNonEmpty();
         String organizationId = Some.uuid().toString();
@@ -61,7 +61,7 @@ public class SubmitSigningRequestStepEndToEndTest {
         CredentialsStore credentialStore = CredentialStoreUtils.getCredentialStore(j.jenkins);
         assert credentialStore != null;
         CredentialStoreUtils.addCredentials(credentialStore, CredentialsScope.SYSTEM, trustedBuildSystemTokenCredentialId, trustedBuildSystemToken);
-        CredentialStoreUtils.addCredentials(credentialStore, CredentialsScope.SYSTEM, ciUserTokenCredentialId, ciUserToken);
+        CredentialStoreUtils.addCredentials(credentialStore, CredentialsScope.SYSTEM, apiTokenCredentialId, apiToken);
 
         String apiUrl = getMockUrl();
         String downloadSignedArtifact = "downloadSignedArtifact";
@@ -88,8 +88,8 @@ public class SubmitSigningRequestStepEndToEndTest {
                         .withBody(signedArtifactBytes)));
  
         WorkflowJob workflowJob = withOptionalFields
-                ? createWorkflowJobWithOptionalParameters(apiUrl, trustedBuildSystemTokenCredentialId, ciUserTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, true)
-                : createWorkflowJob(apiUrl, trustedBuildSystemTokenCredentialId, ciUserTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, true);
+                ? createWorkflowJobWithOptionalParameters(apiUrl, trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, true)
+                : createWorkflowJob(apiUrl, trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, true);
 
         String remoteUrl = Some.url();
         BuildData buildData = new BuildData(Some.stringNonEmpty());
@@ -113,9 +113,9 @@ public class SubmitSigningRequestStepEndToEndTest {
         assertTrue(run.getLog().contains("<returnValue>:\"" + signingRequestId + "\""));
 
         if (withOptionalFields)
-            assertRequest(ciUserToken, trustedBuildSystemToken, unsignedArtifactString, remoteUrl, organizationId, projectSlug, signingPolicySlug, artifactConfigurationSlug, description);
+            assertRequest(apiToken, trustedBuildSystemToken, unsignedArtifactString, remoteUrl, organizationId, projectSlug, signingPolicySlug, artifactConfigurationSlug, description);
         else
-            assertRequest(ciUserToken, trustedBuildSystemToken, unsignedArtifactString, remoteUrl, organizationId, projectSlug, signingPolicySlug);
+            assertRequest(apiToken, trustedBuildSystemToken, unsignedArtifactString, remoteUrl, organizationId, projectSlug, signingPolicySlug);
     }
 
     @Theory
@@ -123,8 +123,8 @@ public class SubmitSigningRequestStepEndToEndTest {
         String unsignedArtifactString = Some.stringNonEmpty();
         String trustedBuildSystemTokenCredentialId = Some.stringNonEmpty();
         String trustedBuildSystemToken = Some.stringNonEmpty();
-        String ciUserTokenCredentialId = Some.stringNonEmpty();
-        String ciUserToken = Some.stringNonEmpty();
+        String apiTokenCredentialId = Some.stringNonEmpty();
+        String apiToken = Some.stringNonEmpty();
         String projectSlug = Some.stringNonEmpty();
         String signingPolicySlug = Some.stringNonEmpty();
         String organizationId = Some.uuid().toString();
@@ -135,7 +135,7 @@ public class SubmitSigningRequestStepEndToEndTest {
         CredentialsStore credentialStore = CredentialStoreUtils.getCredentialStore(j.jenkins);
         assert credentialStore != null;
         CredentialStoreUtils.addCredentials(credentialStore, CredentialsScope.SYSTEM, trustedBuildSystemTokenCredentialId, trustedBuildSystemToken);
-        CredentialStoreUtils.addCredentials(credentialStore, CredentialsScope.SYSTEM, ciUserTokenCredentialId, ciUserToken);
+        CredentialStoreUtils.addCredentials(credentialStore, CredentialsScope.SYSTEM, apiTokenCredentialId, apiToken);
 
         String apiUrl = getMockUrl();
         wireMockRule.stubFor(post(urlEqualTo("/v1/" + organizationId + "/SigningRequests"))
@@ -145,8 +145,8 @@ public class SubmitSigningRequestStepEndToEndTest {
                         .withHeader("Location", getMockUrl("v1/" + organizationId + "/SigningRequests/" + signingRequestId))));
 
         WorkflowJob workflowJob = withOptionalFields
-                ? createWorkflowJobWithOptionalParameters(apiUrl, trustedBuildSystemTokenCredentialId, ciUserTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, false)
-                : createWorkflowJob(apiUrl, trustedBuildSystemTokenCredentialId, ciUserTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, false);
+                ? createWorkflowJobWithOptionalParameters(apiUrl, trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, false)
+                : createWorkflowJob(apiUrl, trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, false);
 
         String remoteUrl = Some.url();
         BuildData buildData = new BuildData(Some.stringNonEmpty());
@@ -167,9 +167,9 @@ public class SubmitSigningRequestStepEndToEndTest {
         assertTrue(run.getLog().contains("<returnValue>:\"" + signingRequestId + "\""));
 
         if (withOptionalFields)
-            assertRequest(ciUserToken, trustedBuildSystemToken, unsignedArtifactString, remoteUrl, organizationId, projectSlug, signingPolicySlug, artifactConfigurationSlug, description);
+            assertRequest(apiToken, trustedBuildSystemToken, unsignedArtifactString, remoteUrl, organizationId, projectSlug, signingPolicySlug, artifactConfigurationSlug, description);
         else
-            assertRequest(ciUserToken, trustedBuildSystemToken, unsignedArtifactString, remoteUrl, organizationId, projectSlug, signingPolicySlug);
+            assertRequest(apiToken, trustedBuildSystemToken, unsignedArtifactString, remoteUrl, organizationId, projectSlug, signingPolicySlug);
     }
 
     @Theory
@@ -221,7 +221,7 @@ public class SubmitSigningRequestStepEndToEndTest {
 
     private WorkflowJob createWorkflowJobWithOptionalParameters(String apiUrl,
                                                                 String trustedBuildSystemTokenCredentialId,
-                                                                String ciUserTokenCredentialId,
+                                                                String apiTokenCredentialId,
                                                                 String organizationId,
                                                                 String projectSlug,
                                                                 String signingPolicySlug,
@@ -236,7 +236,7 @@ public class SubmitSigningRequestStepEndToEndTest {
                         "inputArtifactPath: 'unsigned.exe', " +
                         "outputArtifactPath: 'signed.exe', " +
                         "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
-                        "ciUserTokenCredentialId: '" + ciUserTokenCredentialId + "'," +
+                        "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
                         "projectSlug: '" + projectSlug + "'," +
                         "signingPolicySlug: '" + signingPolicySlug + "'," +
@@ -250,7 +250,7 @@ public class SubmitSigningRequestStepEndToEndTest {
 
     private WorkflowJob createWorkflowJob(String apiUrl,
                                           String trustedBuildSystemTokenCredentialId,
-                                          String ciUserTokenCredentialId,
+                                          String apiTokenCredentialId,
                                           String organizationId,
                                           String projectSlug,
                                           String signingPolicySlug,
@@ -267,7 +267,7 @@ public class SubmitSigningRequestStepEndToEndTest {
                         "inputArtifactPath: 'unsigned.exe', " +
                         outputArtifactPath +
                         "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
-                        "ciUserTokenCredentialId: '" + ciUserTokenCredentialId + "'," +
+                        "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
                         "projectSlug: '" + projectSlug + "'," +
                         "signingPolicySlug: '" + signingPolicySlug + "'," +
@@ -278,7 +278,7 @@ public class SubmitSigningRequestStepEndToEndTest {
     }
 
     private void assertRequest(
-            String ciUserToken,
+            String apiToken,
             String trustedBuildSystemToken,
             String unsignedArtifactString,
             String remoteUrl,
@@ -287,7 +287,7 @@ public class SubmitSigningRequestStepEndToEndTest {
             String signingPolicySlug) {
 
         wireMockRule.verify(postRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests"))
-                .withHeader("Authorization", equalTo("Bearer " + ciUserToken + ":" + trustedBuildSystemToken))
+                .withHeader("Authorization", equalTo("Bearer " + apiToken + ":" + trustedBuildSystemToken))
                 .withRequestBodyPart(aMultipart().withBody(equalTo(projectSlug)).build())
                 .withRequestBodyPart(aMultipart().withBody(equalTo(signingPolicySlug)).build())
                 .withRequestBodyPart(aMultipart().withBody(equalTo(remoteUrl)).build()));
@@ -296,7 +296,7 @@ public class SubmitSigningRequestStepEndToEndTest {
     }
 
     private void assertRequest(
-            String ciUserToken,
+            String apiToken,
             String trustedBuildSystemToken,
             String unsignedArtifactString,
             String remoteUrl,
@@ -307,7 +307,7 @@ public class SubmitSigningRequestStepEndToEndTest {
             String description) {
 
         wireMockRule.verify(postRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests"))
-                .withHeader("Authorization", equalTo("Bearer " + ciUserToken + ":" + trustedBuildSystemToken))
+                .withHeader("Authorization", equalTo("Bearer " + apiToken + ":" + trustedBuildSystemToken))
                 .withRequestBodyPart(aMultipart().withBody(equalTo(projectSlug)).build())
                 .withRequestBodyPart(aMultipart().withBody(equalTo(signingPolicySlug)).build())
                 .withRequestBodyPart(aMultipart().withBody(equalTo(remoteUrl)).build())


### PR DESCRIPTION
To stay consistent with SignPath documentation and terminology, we are renaming "CI User Token" to "API Token" everywhere across the plugin. This is a breaking change; the submitSigningRequest task parameter ciUserTokenCredentialId was renamed to apiTokenCredentialId. That's why the major version of the plugin was increased.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
```

