### PR TITLE
SIGN-6572 - log plug-in, JDK, and Jenkins versions to User-Agent header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>io.signpath.javaclient</groupId>
             <artifactId>api-client</artifactId>
-            <version>1.0.7</version>
+            <version>1.0.8</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
+++ b/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.model.Jenkins;
 
 public class SignPathClientFacade implements SignPathFacade {
 
@@ -41,7 +42,8 @@ public class SignPathClientFacade implements SignPathFacade {
                 apiConfiguration.getServiceUnavailableTimeoutInSeconds(),
                 apiConfiguration.getUploadAndDownloadRequestTimeoutInSeconds(),
                 apiConfiguration.getWaitForCompletionTimeoutInSeconds(),
-                apiConfiguration.getWaitBetweenReadinessChecksInSeconds()
+                apiConfiguration.getWaitBetweenReadinessChecksInSeconds(),
+                buildUserAgent()
             ));
     }
 
@@ -129,5 +131,13 @@ public class SignPathClientFacade implements SignPathFacade {
         originParameters.put("RepositoryData.SourceControlManagementType", origin.getRepositoryMetadata().getSourceControlManagementType());
         
         return originParameters;
-    } 
+    }
+    
+    private String buildUserAgent(){
+        return String.format("SignPathJenkinsCIPlugin/%1$s (OpenJDK %2$s; Jenkins %3$s)",
+                SignPathClientFacade.class.getPackage().getImplementationVersion(),
+                System.getProperty("java.version"),
+                Jenkins.getVersion().toString()
+                );
+    }
 }

--- a/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
+++ b/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
@@ -136,7 +136,7 @@ public class SignPathClientFacade implements SignPathFacade {
     
     private String buildUserAgent(){
         
-        return String.format("SignPathJenkinsCIPlugin/%1$s (OpenJDK %2$s; Jenkins %3$s)",
+        return String.format("SignPath.Plugins.Jenkins/%1$s (OpenJDK %2$s; Jenkins %3$s)",
                 SignPathClientFacade.class.getPackage().getImplementationVersion(),
                 System.getProperty("java.version"),
                 Jenkins.getVersion()

--- a/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
+++ b/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.signpath.ApiIntegration.SignPathClient;
 //</editor-fold>
+import hudson.util.VersionNumber;
 import io.jenkins.plugins.signpath.ApiIntegration.ApiConfiguration;
 import io.jenkins.plugins.signpath.ApiIntegration.Model.SigningRequestModel;
 import io.jenkins.plugins.signpath.ApiIntegration.Model.SigningRequestOriginModel;
@@ -134,10 +135,11 @@ public class SignPathClientFacade implements SignPathFacade {
     }
     
     private String buildUserAgent(){
+        
         return String.format("SignPathJenkinsCIPlugin/%1$s (OpenJDK %2$s; Jenkins %3$s)",
                 SignPathClientFacade.class.getPackage().getImplementationVersion(),
                 System.getProperty("java.version"),
-                Jenkins.getVersion().toString()
+                Jenkins.getVersion()
                 );
     }
 }


### PR DESCRIPTION
SIGN-6572 - Include the plug-in, JDK, and Jenkins versions in the User-Agent header for all SignPath API requests.

```[tasklist]
### Submitter checklist
- [ x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x ] Ensure that the pull request title represents the desired changelog entry
- [ x ] Please describe what you did
- [ x ] Link to relevant issues in GitHub or Jira
- [ x ] Link to relevant pull requests, esp. upstream and downstream changes
```
