### PR TITLE
SIGN-7466 - removed apiUrl parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>${revision}.${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
-        <revision>2.2.0</revision>
+        <revision>3.0.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <jenkins.baseline>2.361</jenkins.baseline> 
         <jenkins.version>${jenkins.baseline}.4</jenkins.version>

--- a/src/main/java/io/jenkins/plugins/signpath/Common/PluginConstants.java
+++ b/src/main/java/io/jenkins/plugins/signpath/Common/PluginConstants.java
@@ -7,6 +7,6 @@ public final class PluginConstants {
     private PluginConstants() {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }
-    public static final String DEFAULT_API_URL = "https://app.signpath.io/api/";
+    public static final String DEFAULT_API_URL = "https://app.signpath.io/Api/";
     public static final String DEFAULT_TBS_CREDENTIAL_ID = "SignPath.TrustedBuildSystemToken";
 }

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathPluginGlobalConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathPluginGlobalConfiguration.java
@@ -9,6 +9,8 @@ import io.jenkins.plugins.signpath.Common.PluginConstants;
 import io.jenkins.plugins.signpath.Exceptions.SecretNotFoundException;
 import io.jenkins.plugins.signpath.SecretRetrieval.CredentialBasedSecretRetriever;
 import io.jenkins.plugins.signpath.SecretRetrieval.SecretRetriever;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.UUID;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.QueryParameter;
@@ -16,7 +18,7 @@ import org.kohsuke.stapler.QueryParameter;
 @Extension
 public class SignPathPluginGlobalConfiguration extends GlobalConfiguration {
 
-    private String defaultApiURL = PluginConstants.DEFAULT_API_URL;
+    private String apiURL = PluginConstants.DEFAULT_API_URL;
     private String defaultTrustedBuildSystemCredentialId = PluginConstants.DEFAULT_TBS_CREDENTIAL_ID;
     private String defaultOrganizationId;
 
@@ -26,14 +28,27 @@ public class SignPathPluginGlobalConfiguration extends GlobalConfiguration {
 
     // default DefaultApiURL
     
-    public String getDefaultApiURL() {
-        return defaultApiURL;
+    public String getApiURL() {
+        return apiURL;
     }
 
     @DataBoundSetter
-    public void setDefaultApiURL(String url) {
-        this.defaultApiURL = url;
+    public void setApiURL(String url) {
+        this.apiURL = url;
         save();
+    }
+
+    public FormValidation doCheckApiURL(@QueryParameter String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return FormValidation.error("Api URL is required"); // empty value is allowed
+        }
+        
+        try {
+            new URL(value);
+            return FormValidation.ok();
+        } catch (MalformedURLException e) {
+            return FormValidation.error("Api URL must be a valid url");
+        }        
     }
     
     // DefaultTrustedBuildSystemCredential

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
@@ -43,7 +43,12 @@ public abstract class SignPathStepBase extends Step {
 
     public String getApiUrl() {
         SignPathPluginGlobalConfiguration config = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
-        return config.getApiURL();
+        if(config != null) {
+            return config.getApiURL();
+        }
+        else {
+            return null;
+        }
     }
 
     public String getTrustedBuildSystemTokenCredentialId() {

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
@@ -23,8 +23,6 @@ import java.util.function.Function;
  * @see io.jenkins.plugins.signpath.ApiIntegration.ApiConfiguration
  */
 public abstract class SignPathStepBase extends Step {
-    private String apiUrl;
-
     // we set some sensible defaults for various timeouts, note that the
     // serviceUnavailableTimeoutInSeconds is used for upload, download and wait operations
     private int serviceUnavailableTimeoutInSeconds = (int) TimeUnit.MINUTES.toSeconds(10);
@@ -44,13 +42,8 @@ public abstract class SignPathStepBase extends Step {
     private String apiTokenCredentialId = "SignPath.ApiToken";
 
     public String getApiUrl() {
-        return apiUrl;
-    }
-
-    // we use this method in the task to avoid overriding empty values at build level
-    // with the values from the global configuration
-    public String getApiUrlWithGlobalConfig() {
-        return getWithGlobalConfig(apiUrl, SignPathPluginGlobalConfiguration::getDefaultApiURL);
+        SignPathPluginGlobalConfiguration config = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
+        return config.getApiURL();
     }
 
     public String getTrustedBuildSystemTokenCredentialId() {
@@ -88,11 +81,6 @@ public abstract class SignPathStepBase extends Step {
     }
 
     @DataBoundSetter
-    public void setApiUrl(String apiUrl) {
-        this.apiUrl = apiUrl;
-    }
-
-    @DataBoundSetter
     public void setTrustedBuildSystemTokenCredentialId(String trustedBuildSystemTokenCredentialId) {
         this.trustedBuildSystemTokenCredentialId = trustedBuildSystemTokenCredentialId;
     }
@@ -124,20 +112,12 @@ public abstract class SignPathStepBase extends Step {
 
     public ApiConfiguration getAndValidateApiConfiguration() throws SignPathStepInvalidArgumentException {
         return new ApiConfiguration(
-                ensureValidURL(getApiUrlWithGlobalConfig()),
+                ensureValidURL(getApiUrl()),
                 getServiceUnavailableTimeoutInSeconds(),
                 getUploadAndDownloadRequestTimeoutInSeconds(),
                 getWaitForCompletionTimeoutInSeconds(),
                 getWaitForPowerShellTimeoutInSeconds(),
                 getWaitBetweenReadinessChecksInSeconds());
-    }
-
-    protected URL ensureValidURL(String apiUrl) throws SignPathStepInvalidArgumentException {
-        try {
-            return new URL(apiUrl);
-        } catch (MalformedURLException e) {
-            throw new SignPathStepInvalidArgumentException(apiUrl + " must be a valid url");
-        }
     }
 
     protected UUID ensureValidUUID(String input, String name) throws SignPathStepInvalidArgumentException {
@@ -164,5 +144,13 @@ public abstract class SignPathStepBase extends Step {
         }
 
         return value;
+    }
+
+    protected URL ensureValidURL(String apiUrl) throws SignPathStepInvalidArgumentException {
+        try {
+            return new URL(apiUrl);
+        } catch (MalformedURLException e) {
+            throw new SignPathStepInvalidArgumentException(apiUrl + " must be a valid url");
+        }
     }
 }

--- a/src/main/resources/io/jenkins/plugins/signpath/SignPathPluginGlobalConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/signpath/SignPathPluginGlobalConfiguration/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="${%Code Signing with SignPath}">
-    <f:entry title="${%Default Api URL}" field="defaultApiURL">
+    <f:entry title="${%Api URL}" field="apiURL">
       <f:textbox />
     </f:entry>
     <f:entry title="${%Default Trusted Build System Credential ID}" field="defaultTrustedBuildSystemCredentialId">

--- a/src/test/java/io/jenkins/plugins/signpath/SignPathPluginGlobalConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/SignPathPluginGlobalConfigurationTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import hudson.util.FormValidation;
+import hudson.util.FormValidation.Kind;
 import io.jenkins.plugins.signpath.Exceptions.SecretNotFoundException;
 import io.jenkins.plugins.signpath.SecretRetrieval.CredentialBasedSecretRetriever;
 import io.jenkins.plugins.signpath.TestUtils.CredentialStoreUtils;
@@ -35,8 +36,22 @@ public class SignPathPluginGlobalConfigurationTest {
     @Test
     public void testGetAndSetDefaultApiURL() {
         String url = "https://api.example.com";
-        config.setDefaultApiURL(url);
-        assertEquals("The default API URL should match the set value.", url, config.getDefaultApiURL());
+        config.setApiURL(url);
+        assertEquals("The API URL should match the set value.", url, config.getApiURL());
+    }
+    
+    @Test
+    public void testDoCheckApiURL_Valid() {
+        String validUrl = "https://api.example.com";
+        FormValidation result = config.doCheckApiURL(validUrl);
+        assertEquals("Validation should pass with a valid url.", Kind.OK, result.kind);
+    }
+
+    @Test
+    public void testDoCheckApiURL_Invalid() {
+        String invalidUrl = "invalid-url";
+        FormValidation result = config.doCheckApiURL(invalidUrl);
+        assertEquals("Validation should fail.", FormValidation.Kind.ERROR, result.kind);
     }
 
     @Test


### PR DESCRIPTION
### Testing done

- I tested the configuration with apiUrl parameter provided in the Jenkinsfile, to ensure that the plugin ignores the value. The plugin behaves as expected and reports that the apiUrl parameter is not supported.
- I also tested the case where the apiUrl parameter is not provided in the Jenkinsfile. In this scenario, the plugin correctly retrieves the value from the global configuration. 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue