### PR TITLE
SIGN-7475 - removed TBS token task parameter

### DIFF
--- a/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStep.java
+++ b/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStep.java
@@ -43,7 +43,7 @@ public class GetSignedArtifactStep extends SignPathStepBase {
         GetSignedArtifactStepInput input =  new GetSignedArtifactStepInput(
                 ensureValidUUID(getOrganizationIdWithGlobalConfig(), "organizationId"),
                 ensureValidUUID(getSigningRequestId(), "signingRequestId"),
-                ensureNotNull(getTrustedBuildSystemTokenCredentialIdWithGlobalConfig(), "trustedBuildSystemTokenCredentialId"),
+                ensureNotNull(getTrustedBuildSystemTokenCredentialId(), "trustedBuildSystemTokenCredentialId"),
                 ensureNotNull(getApiTokenCredentialId(), "apiTokenCredentialId"),
                 ensureNotNull(getOutputArtifactPath(), "outputArtifactPath"));
 

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathPluginGlobalConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathPluginGlobalConfiguration.java
@@ -19,7 +19,7 @@ import org.kohsuke.stapler.QueryParameter;
 public class SignPathPluginGlobalConfiguration extends GlobalConfiguration {
 
     private String apiURL = PluginConstants.DEFAULT_API_URL;
-    private String defaultTrustedBuildSystemCredentialId = PluginConstants.DEFAULT_TBS_CREDENTIAL_ID;
+    private String trustedBuildSystemCredentialId = PluginConstants.DEFAULT_TBS_CREDENTIAL_ID;
     private String defaultOrganizationId;
 
     public SignPathPluginGlobalConfiguration() {
@@ -53,17 +53,17 @@ public class SignPathPluginGlobalConfiguration extends GlobalConfiguration {
     
     // DefaultTrustedBuildSystemCredential
     
-    public String getDefaultTrustedBuildSystemCredentialId() {
-        return defaultTrustedBuildSystemCredentialId;
+    public String getTrustedBuildSystemCredentialId() {
+        return trustedBuildSystemCredentialId;
     }
 
     @DataBoundSetter
-    public void setDefaultTrustedBuildSystemCredentialId(String tbsCredentialId) {
-        this.defaultTrustedBuildSystemCredentialId = tbsCredentialId;
+    public void setTrustedBuildSystemCredentialId(String tbsCredentialId) {
+        this.trustedBuildSystemCredentialId = tbsCredentialId;
         save();
     }
     
-    public FormValidation doCheckDefaultTrustedBuildSystemCredentialId(@QueryParameter String value) {
+    public FormValidation doCheckTrustedBuildSystemCredentialId(@QueryParameter String value) {
         if (value == null || value.trim().isEmpty()) {
             return FormValidation.ok(); // empty value is allowed
         }

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
@@ -41,13 +41,11 @@ public abstract class SignPathStepBase extends Step {
     private String apiTokenCredentialId = "SignPath.ApiToken";
 
     public String getApiUrl() {
-        SignPathPluginGlobalConfiguration config = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
-        return config != null ? config.getApiURL() : null;
+        return getSignPathConfig().getApiURL();
     }
 
     public String getTrustedBuildSystemTokenCredentialId() {
-        SignPathPluginGlobalConfiguration config = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
-        return config != null ? config.getTrustedBuildSystemCredentialId() : null;
+        return getSignPathConfig().getTrustedBuildSystemCredentialId();
     }
     
     public String getApiTokenCredentialId() {
@@ -141,5 +139,13 @@ public abstract class SignPathStepBase extends Step {
         } catch (MalformedURLException e) {
             throw new SignPathStepInvalidArgumentException(apiUrl + " must be a valid url");
         }
+    }
+    
+    protected SignPathPluginGlobalConfiguration getSignPathConfig() {
+        SignPathPluginGlobalConfiguration config = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
+        if (config == null) {
+            throw new IllegalStateException("SignPathPluginGlobalConfiguration is not available. Ensure it is properly configured.");
+        }
+        return config;
     }
 }

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
@@ -38,29 +38,18 @@ public abstract class SignPathStepBase extends Step {
     // also a timeout that is too high is not useful anymore
     private int waitForPowerShellTimeoutInSeconds = (int) TimeUnit.MINUTES.toSeconds(30);
 
-    private String trustedBuildSystemTokenCredentialId;
     private String apiTokenCredentialId = "SignPath.ApiToken";
 
     public String getApiUrl() {
         SignPathPluginGlobalConfiguration config = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
-        if(config != null) {
-            return config.getApiURL();
-        }
-        else {
-            return null;
-        }
+        return config != null ? config.getApiURL() : null;
     }
 
     public String getTrustedBuildSystemTokenCredentialId() {
-        return trustedBuildSystemTokenCredentialId;
+        SignPathPluginGlobalConfiguration config = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
+        return config != null ? config.getTrustedBuildSystemCredentialId() : null;
     }
-
-    // we use this method in the task to avoid overriding empty values at build level
-    // with the values from the global configuration
-    public String getTrustedBuildSystemTokenCredentialIdWithGlobalConfig() {
-        return getWithGlobalConfig(trustedBuildSystemTokenCredentialId, SignPathPluginGlobalConfiguration::getDefaultTrustedBuildSystemCredentialId);
-    }
-
+    
     public String getApiTokenCredentialId() {
         return apiTokenCredentialId;
     }
@@ -83,11 +72,6 @@ public abstract class SignPathStepBase extends Step {
     
     public int getWaitBetweenReadinessChecksInSeconds() {
         return waitBetweenReadinessChecksInSeconds;
-    }
-
-    @DataBoundSetter
-    public void setTrustedBuildSystemTokenCredentialId(String trustedBuildSystemTokenCredentialId) {
-        this.trustedBuildSystemTokenCredentialId = trustedBuildSystemTokenCredentialId;
     }
 
     @DataBoundSetter

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
@@ -54,7 +54,7 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
         String outputArtifactPath = waitForCompletion ? ensureNotNull(getOutputArtifactPath(), "outputArtifactPath") : null;
         SubmitSigningRequestStepInput input = new SubmitSigningRequestStepInput(
                 ensureValidUUID(getOrganizationIdWithGlobalConfig(), "organizationId"),
-                ensureNotNull(getTrustedBuildSystemTokenCredentialIdWithGlobalConfig(), "trustedBuildSystemTokenCredentialId"),
+                ensureNotNull(getTrustedBuildSystemTokenCredentialId(), "trustedBuildSystemTokenCredentialId"),
                 ensureNotNull(getApiTokenCredentialId(), "apiTokenCredentialId"),
                 ensureNotNull(getProjectSlug(), "projectSlug"),
                 getArtifactConfigurationSlug(),

--- a/src/main/resources/io/jenkins/plugins/signpath/SignPathPluginGlobalConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/signpath/SignPathPluginGlobalConfiguration/config.jelly
@@ -4,7 +4,7 @@
     <f:entry title="${%Api URL}" field="apiURL">
       <f:textbox />
     </f:entry>
-    <f:entry title="${%Default Trusted Build System Credential ID}" field="defaultTrustedBuildSystemCredentialId">
+    <f:entry title="${%Trusted Build System Credential ID}" field="trustedBuildSystemCredentialId">
       <f:textbox />
     </f:entry>
     <f:entry title="${%Default Organization ID}" field="defaultOrganizationId">

--- a/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
@@ -55,6 +55,7 @@ public class GetSignedArtifactStepEndToEndTest {
         String apiUrl = getMockUrl();
         SignPathPluginGlobalConfiguration globalConfig = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
         globalConfig.setApiURL(apiUrl);
+        globalConfig.setTrustedBuildSystemCredentialId(trustedBuildSystemTokenCredentialId);
         
         wireMockRule.stubFor(get(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId))
                 .willReturn(aResponse()
@@ -66,7 +67,7 @@ public class GetSignedArtifactStepEndToEndTest {
                         .withStatus(200)
                         .withBody(signedArtifactBytes)));
 
-        WorkflowJob workflowJob = createWorkflowJob(trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, signingRequestId);
+        WorkflowJob workflowJob = createWorkflowJob(apiTokenCredentialId, organizationId, signingRequestId);
 
         String remoteUrl = Some.url();
         BuildData buildData = new BuildData(Some.stringNonEmpty());
@@ -109,14 +110,12 @@ public class GetSignedArtifactStepEndToEndTest {
         assertTrue(run.getLog().contains("SignPathStepInvalidArgumentException"));
     }
 
-    private WorkflowJob createWorkflowJob(String trustedBuildSystemTokenCredentialId,
-                                          String apiTokenCredentialId,
+    private WorkflowJob createWorkflowJob(String apiTokenCredentialId,
                                           String organizationId,
                                           String signingRequestId) throws IOException {
         return j.createWorkflow("SignPath",
                 "getSignedArtifact(" +
                         "outputArtifactPath: 'signed.exe', " +
-                        "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
                         "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
                         "signingRequestId: '" + signingRequestId + "'," +

--- a/src/test/java/io/jenkins/plugins/signpath/SignPathPluginGlobalConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/SignPathPluginGlobalConfigurationTest.java
@@ -34,7 +34,7 @@ public class SignPathPluginGlobalConfigurationTest {
     }
 
     @Test
-    public void testGetAndSetDefaultApiURL() {
+    public void testGetAndSetApiURL() {
         String url = "https://api.example.com";
         config.setApiURL(url);
         assertEquals("The API URL should match the set value.", url, config.getApiURL());
@@ -55,30 +55,30 @@ public class SignPathPluginGlobalConfigurationTest {
     }
 
     @Test
-    public void testGetAndSetDefaultTrustedBuildSystemCredentialId() {
+    public void testGetAndSetTrustedBuildSystemCredentialId() {
         String credentialId = "test-credential-id";
-        config.setDefaultTrustedBuildSystemCredentialId(credentialId);
-        assertEquals("The TBS Credential ID should match the set value.", credentialId, config.getDefaultTrustedBuildSystemCredentialId());
+        config.setTrustedBuildSystemCredentialId(credentialId);
+        assertEquals("The TBS Credential ID should match the set value.", credentialId, config.getTrustedBuildSystemCredentialId());
     }
     
     @Test
-    public void testDoCheckDefaultTrustedBuildSystemCredentialId_Valid() throws Exception {
+    public void testDoCheckTrustedBuildSystemCredentialId_Valid() throws Exception {
         String validCredentialId = "valid-id";
         CredentialsStore credentialStore = CredentialStoreUtils.getCredentialStore(j.jenkins);
         assert credentialStore != null;
         CredentialStoreUtils.addCredentials(credentialStore, CredentialsScope.SYSTEM, validCredentialId, "dummySecret");
-        FormValidation result = config.doCheckDefaultTrustedBuildSystemCredentialId(validCredentialId);
+        FormValidation result = config.doCheckTrustedBuildSystemCredentialId(validCredentialId);
         assertEquals("Validation should pass with a valid credential ID.", FormValidation.ok(), result);
     }
 
     @Test
-    public void testDoCheckDefaultTrustedBuildSystemCredentialId_Invalid() throws Exception {
+    public void testDoCheckTrustedBuildSystemCredentialId_Invalid() throws Exception {
         String invalidCredentialId = "invalid-id";
         doThrow(new SecretNotFoundException("Secret not found"))
                 .when(secretRetrieverMock)
                 .retrieveSecret(eq(invalidCredentialId), any());
 
-        FormValidation result = config.doCheckDefaultTrustedBuildSystemCredentialId(invalidCredentialId);
+        FormValidation result = config.doCheckTrustedBuildSystemCredentialId(invalidCredentialId);
         assertEquals("Validation should fail.", FormValidation.Kind.ERROR, result.kind);
     }
 

--- a/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
@@ -92,9 +92,10 @@ public class SubmitSigningRequestStepEndToEndTest {
  
         SignPathPluginGlobalConfiguration globalConfig = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
         globalConfig.setApiURL(apiUrl);
+        globalConfig.setTrustedBuildSystemCredentialId(trustedBuildSystemTokenCredentialId);
         WorkflowJob workflowJob = withOptionalFields
-                ? createWorkflowJobWithOptionalParameters(trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, userDefinedParamName, userDefinedParamValue, true)
-                : createWorkflowJob(trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, true);
+                ? createWorkflowJobWithOptionalParameters(apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, userDefinedParamName, userDefinedParamValue, true)
+                : createWorkflowJob(apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, true);
 
         String remoteUrl = Some.url();
         BuildData buildData = new BuildData(Some.stringNonEmpty());
@@ -152,11 +153,12 @@ public class SubmitSigningRequestStepEndToEndTest {
                         .withHeader("Location", getMockUrl("v1/" + organizationId + "/SigningRequests/" + signingRequestId))));
 
         SignPathPluginGlobalConfiguration globalConfig = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
-        globalConfig.setApiURL(apiUrl);                
+        globalConfig.setApiURL(apiUrl);      
+        globalConfig.setTrustedBuildSystemCredentialId(trustedBuildSystemTokenCredentialId);
         
         WorkflowJob workflowJob = withOptionalFields
-                ? createWorkflowJobWithOptionalParameters(trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, userDefinedParamName, userDefinedParamValue, false)
-                : createWorkflowJob(trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, false);
+                ? createWorkflowJobWithOptionalParameters(apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, userDefinedParamName, userDefinedParamValue, false)
+                : createWorkflowJob(apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, false);
 
         String remoteUrl = Some.url();
         BuildData buildData = new BuildData(Some.stringNonEmpty());
@@ -211,8 +213,9 @@ public class SubmitSigningRequestStepEndToEndTest {
 
         SignPathPluginGlobalConfiguration globalConfig = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
         globalConfig.setApiURL(getMockUrl());
+        globalConfig.setTrustedBuildSystemCredentialId(Some.stringNonEmpty());
         
-        WorkflowJob workflowJob = createWorkflowJob(Some.stringNonEmpty(), Some.stringNonEmpty(), organizationId, Some.stringNonEmpty(), Some.stringNonEmpty(), Some.stringNonEmpty(), false);
+        WorkflowJob workflowJob = createWorkflowJob(Some.stringNonEmpty(), organizationId, Some.stringNonEmpty(), Some.stringNonEmpty(), Some.stringNonEmpty(), false);
 
         BuildData buildData = new BuildData(Some.stringNonEmpty());
         buildData.saveBuild(BuildDataDomainObjectMother.createRandomBuild(1));
@@ -232,8 +235,7 @@ public class SubmitSigningRequestStepEndToEndTest {
         wireMockRule.verify(exactly(0), postRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests")));
     }
 
-    private WorkflowJob createWorkflowJobWithOptionalParameters(String trustedBuildSystemTokenCredentialId,
-                                                                String apiTokenCredentialId,
+    private WorkflowJob createWorkflowJobWithOptionalParameters(String apiTokenCredentialId,
                                                                 String organizationId,
                                                                 String projectSlug,
                                                                 String signingPolicySlug,
@@ -249,7 +251,6 @@ public class SubmitSigningRequestStepEndToEndTest {
                         "echo '<returnValue>:\"'+ submitSigningRequest(" +
                         "inputArtifactPath: 'unsigned.exe', " +
                         "outputArtifactPath: 'signed.exe', " +
-                        "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
                         "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
                         "projectSlug: '" + projectSlug + "'," +
@@ -263,8 +264,7 @@ public class SubmitSigningRequestStepEndToEndTest {
                         "waitForCompletionTimeoutInSeconds: 10) + '\"';");
     }
 
-    private WorkflowJob createWorkflowJob(String trustedBuildSystemTokenCredentialId,
-                                          String apiTokenCredentialId,
+    private WorkflowJob createWorkflowJob(String apiTokenCredentialId,
                                           String organizationId,
                                           String projectSlug,
                                           String signingPolicySlug,
@@ -280,7 +280,6 @@ public class SubmitSigningRequestStepEndToEndTest {
                         "echo '<returnValue>:\"'+ submitSigningRequest(" +
                         "inputArtifactPath: 'unsigned.exe', " +
                         outputArtifactPath +
-                        "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
                         "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
                         "projectSlug: '" + projectSlug + "'," +


### PR DESCRIPTION
### Testing done
- I tested the configuration with TBS Credentials ID parameter provided in the Jenkinsfile, to ensure that the plugin ignores the value. The plugin behaves as expected and reports that the  TBS Credentials ID parameter is not supported.
- I also tested the case where the  TBS Credentials ID parameter is not provided in the Jenkinsfile. In this scenario, the plugin correctly retrieves the value from the global configuration.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
