### PR TITLE
SIGN-7489 - added TBS token, and API Url task params

### DIFF
--- a/build-trigger
+++ b/build-trigger
@@ -1,4 +1,4 @@
 We use this file as a trigger for the Jenkins plugin build pipeline.
 If you want to trigger a new build, just modify it.
 
-Version - 2
+Version - 1

--- a/src/main/java/io/jenkins/plugins/signpath/Common/PluginConstants.java
+++ b/src/main/java/io/jenkins/plugins/signpath/Common/PluginConstants.java
@@ -8,5 +8,6 @@ public final class PluginConstants {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }
     public static final String DEFAULT_API_URL = "https://app.signpath.io/Api/";
-    public static final String DEFAULT_TBS_CREDENTIAL_ID = "SignPath.TrustedBuildSystemToken";
+    public static final String DEFAULT_TBS_TOKEN_CREDENTIAL_ID = "SignPath.TrustedBuildSystemToken";
+    public static final String DEFAULT_API_TOKEN_CREDENTIAL_ID = "SignPath.ApiToken";
 }

--- a/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStep.java
+++ b/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStep.java
@@ -82,6 +82,7 @@ public class GetSignedArtifactStep extends SignPathStepBase {
         }
     }
 
+    @Deprecated
     public String getOrganizationId() throws SignPathStepInvalidArgumentException {
         return organizationId;
     }
@@ -101,6 +102,7 @@ public class GetSignedArtifactStep extends SignPathStepBase {
         return outputArtifactPath;
     }
 
+    @Deprecated
     @DataBoundSetter
     public void setOrganizationId(String organizationId) {
         this.organizationId = organizationId;

--- a/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStep.java
+++ b/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStep.java
@@ -89,7 +89,7 @@ public class GetSignedArtifactStep extends SignPathStepBase {
     public String getOrganizationIdWithGlobal() throws SignPathStepInvalidArgumentException {
         return getWithGlobalConfig(
             organizationId,
-            SignPathPluginGlobalConfiguration::getTrustedBuildSystemCredentialId,
+            SignPathPluginGlobalConfiguration::getOrganizationId,
             "organizationId");
     }
 

--- a/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStep.java
+++ b/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStep.java
@@ -10,7 +10,6 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.signpath.ApiIntegration.ApiConfiguration;
 import io.jenkins.plugins.signpath.Exceptions.SignPathStepInvalidArgumentException;
-import jenkins.model.GlobalConfiguration;
 
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -29,6 +28,7 @@ public class GetSignedArtifactStep extends SignPathStepBase {
     private final static String FunctionName = "getSignedArtifact";
     private final static String DisplayName = "Download SignPath Signed Artifact";
 
+    @Deprecated
     private String organizationId;
     private String signingRequestId;
     private String outputArtifactPath;
@@ -41,7 +41,7 @@ public class GetSignedArtifactStep extends SignPathStepBase {
     @Override
     public StepExecution start(StepContext context) throws IOException, InterruptedException, SignPathStepInvalidArgumentException {
         GetSignedArtifactStepInput input =  new GetSignedArtifactStepInput(
-                ensureValidUUID(getOrganizationIdWithGlobalConfig(), "organizationId"),
+                ensureValidUUID(getOrganizationIdWithGlobal(), "organizationId"),
                 ensureValidUUID(getSigningRequestId(), "signingRequestId"),
                 ensureNotNull(getTrustedBuildSystemTokenCredentialId(), "trustedBuildSystemTokenCredentialId"),
                 ensureNotNull(getApiTokenCredentialId(), "apiTokenCredentialId"),
@@ -82,14 +82,15 @@ public class GetSignedArtifactStep extends SignPathStepBase {
         }
     }
 
-    public String getOrganizationId() {
+    public String getOrganizationId() throws SignPathStepInvalidArgumentException {
         return organizationId;
     }
 
-    // we use this method in the task to avoid overriding empty values at build level
-    // with the values from the global configuration
-    public String getOrganizationIdWithGlobalConfig() {
-        return getWithGlobalConfig(organizationId, SignPathPluginGlobalConfiguration::getDefaultOrganizationId);
+    public String getOrganizationIdWithGlobal() throws SignPathStepInvalidArgumentException {
+        return getWithGlobalConfig(
+            organizationId,
+            SignPathPluginGlobalConfiguration::getTrustedBuildSystemCredentialId,
+            "organizationId");
     }
 
     public String getSigningRequestId() {

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathPluginGlobalConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathPluginGlobalConfiguration.java
@@ -19,8 +19,8 @@ import org.kohsuke.stapler.QueryParameter;
 public class SignPathPluginGlobalConfiguration extends GlobalConfiguration {
 
     private String apiURL = PluginConstants.DEFAULT_API_URL;
-    private String trustedBuildSystemCredentialId = PluginConstants.DEFAULT_TBS_CREDENTIAL_ID;
-    private String defaultOrganizationId;
+    private String trustedBuildSystemCredentialId = PluginConstants.DEFAULT_TBS_TOKEN_CREDENTIAL_ID;
+    private String organizationId;
 
     public SignPathPluginGlobalConfiguration() {
         load();
@@ -40,18 +40,18 @@ public class SignPathPluginGlobalConfiguration extends GlobalConfiguration {
 
     public FormValidation doCheckApiURL(@QueryParameter String value) {
         if (value == null || value.trim().isEmpty()) {
-            return FormValidation.error("Api URL is required"); // empty value is allowed
+            return FormValidation.error("Api URL is required.");
         }
         
         try {
             new URL(value);
             return FormValidation.ok();
         } catch (MalformedURLException e) {
-            return FormValidation.error("Api URL must be a valid url");
+            return FormValidation.error("Api URL must be a valid url.");
         }        
     }
     
-    // DefaultTrustedBuildSystemCredential
+    // TrustedBuildSystemCredential
     
     public String getTrustedBuildSystemCredentialId() {
         return trustedBuildSystemCredentialId;
@@ -65,7 +65,7 @@ public class SignPathPluginGlobalConfiguration extends GlobalConfiguration {
     
     public FormValidation doCheckTrustedBuildSystemCredentialId(@QueryParameter String value) {
         if (value == null || value.trim().isEmpty()) {
-            return FormValidation.ok(); // empty value is allowed
+            return FormValidation.error("Trusted Build System Credential ID is required.");
         }
         
         Jenkins jenkins = Jenkins.get();
@@ -83,25 +83,25 @@ public class SignPathPluginGlobalConfiguration extends GlobalConfiguration {
         }
     }
     
-    // DefaultOrganizationId
+    // organizationId
 
-    public String getDefaultOrganizationId() {
-        return defaultOrganizationId;
+    public String getOrganizationId() {
+        return organizationId;
     }
 
     @DataBoundSetter
-    public void setDefaultOrganizationId(String organizationId) {
-        this.defaultOrganizationId = organizationId;
+    public void setOrganizationId(String organizationId) {
+        this.organizationId = organizationId;
         save();
     }
     
-    public FormValidation doCheckDefaultOrganizationId(@QueryParameter String value) {
+    public FormValidation doCheckOrganizationId(@QueryParameter String value) {
         if (value == null || value.trim().isEmpty()) {
-            return FormValidation.ok(); // empty value is allowed
+            return FormValidation.error("Organization ID is required.");
         }
         
         if (!isValidUUID(value)) {
-            return FormValidation.error("Default Organization ID must be a valid uuid.");
+            return FormValidation.error("Organization ID must be a valid uuid.");
         }
         
         return FormValidation.ok();

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
@@ -40,8 +40,8 @@ public abstract class SignPathStepBase extends Step {
     // also a timeout that is too high is not useful anymore
     private int waitForPowerShellTimeoutInSeconds = (int) TimeUnit.MINUTES.toSeconds(30);
 
-    private String apiUrl = PluginConstants.DEFAULT_API_URL;
-    private String trustedBuildSystemTokenCredentialId = PluginConstants.DEFAULT_TBS_TOKEN_CREDENTIAL_ID;
+    private String apiUrl;
+    private String trustedBuildSystemTokenCredentialId;
     private String apiTokenCredentialId = PluginConstants.DEFAULT_API_TOKEN_CREDENTIAL_ID;
 
     public String getApiUrl() {

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
@@ -164,7 +164,8 @@ public abstract class SignPathStepBase extends Step {
         }
 
         if (stepLevelValue == null || stepLevelValue.isEmpty()) {
-            return globalVal; // step level value is not set, use global value
+            // step level value is not set, use global value
+            return globalVal;
         }
 
         // here we have both values set. We enforce a rule that step level value should be identical to global value
@@ -175,13 +176,7 @@ public abstract class SignPathStepBase extends Step {
                     paramName, globalVal, stepLevelValue));
         }
 
-        if (stepLevelValue == null || stepLevelValue.isEmpty()) {
-            
-            if (config != null) {
-                return globalValueGetter.apply(config);
-            }
-        }
-
+        // here it doesn't matter which value we return, as they are identical
         return stepLevelValue;
     }
 

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
@@ -4,12 +4,14 @@ import io.jenkins.plugins.signpath.ApiIntegration.ApiConfiguration;
 import io.jenkins.plugins.signpath.Common.PluginConstants;
 import io.jenkins.plugins.signpath.Exceptions.SignPathStepInvalidArgumentException;
 import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
 
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import hudson.model.TaskListener;
 
+import java.io.PrintStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.UUID;
@@ -38,9 +40,7 @@ public abstract class SignPathStepBase extends Step {
     // also a timeout that is too high is not useful anymore
     private int waitForPowerShellTimeoutInSeconds = (int) TimeUnit.MINUTES.toSeconds(30);
 
-    @Deprecated
     private String apiUrl = PluginConstants.DEFAULT_API_URL;
-    @Deprecated
     private String trustedBuildSystemTokenCredentialId = PluginConstants.DEFAULT_TBS_TOKEN_CREDENTIAL_ID;
     private String apiTokenCredentialId = PluginConstants.DEFAULT_API_TOKEN_CREDENTIAL_ID;
 
@@ -127,7 +127,7 @@ public abstract class SignPathStepBase extends Step {
 
     public ApiConfiguration getAndValidateApiConfiguration() throws SignPathStepInvalidArgumentException {
         return new ApiConfiguration(
-                ensureValidURL(getApiUrl()),
+                ensureValidURL(getApiUrlWithGlobal()),
                 getServiceUnavailableTimeoutInSeconds(),
                 getUploadAndDownloadRequestTimeoutInSeconds(),
                 getWaitForCompletionTimeoutInSeconds(),
@@ -178,6 +178,17 @@ public abstract class SignPathStepBase extends Step {
 
         // here it doesn't matter which value we return, as they are identical
         return stepLevelValue;
+    }
+
+    protected void logStepParameterDeprecationWarning(TaskListener listener, String parameterName, String globalConfigName) {
+        listener
+            .getLogger()
+            .println(
+                String.format(
+                    "WARNING: The '%s' parameter is deprecated and will be removed in a future release." +
+                    " Please use Jenkins system configuration 'Code Signing with SignPath'->'%s' instead.",
+                    parameterName,
+                    globalConfigName));
     }
 
     protected URL ensureValidURL(String apiUrl) throws SignPathStepInvalidArgumentException {

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
@@ -159,7 +159,7 @@ public abstract class SignPathStepBase extends Step {
         String globalVal = globalValueGetter.apply(config);
 
         if (globalVal == null || globalVal.isEmpty()) {
-            // global value is not set yet, fallback to the obsolete step-level value
+            // global value is not set yet, fallback to the deprecated step-level value
             return stepLevelValue;
         }
 

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
@@ -170,7 +170,9 @@ public abstract class SignPathStepBase extends Step {
         // here we have both values set. We enforce a rule that step level value should be identical to global value
         if (!stepLevelValue.equals(globalVal)) {
             throw new SignPathStepInvalidArgumentException(
-                String.format("Parameter '%s' is configured globally and cannot be changed in pipeline", paramName));
+                String.format(
+                    "Parameter '%s' is configured globally to '%s' and cannot be changed in pipeline to '%s'.", 
+                    paramName, globalVal, stepLevelValue));
         }
 
         if (stepLevelValue == null || stepLevelValue.isEmpty()) {

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
@@ -111,7 +111,7 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
     public String getOrganizationIdWithGlobal() throws SignPathStepInvalidArgumentException {
         return getWithGlobalConfig(
             organizationId,
-            SignPathPluginGlobalConfiguration::getTrustedBuildSystemCredentialId,
+            SignPathPluginGlobalConfiguration::getOrganizationId,
             "organizationId");
     }
 

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
@@ -12,6 +12,7 @@ import io.jenkins.plugins.signpath.ApiIntegration.ApiConfiguration;
 import io.jenkins.plugins.signpath.Exceptions.SignPathStepInvalidArgumentException;
 import jenkins.model.GlobalConfiguration;
 
+import org.apache.http.annotation.Obsolete;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -33,6 +34,7 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
     private final static String FunctionName = "submitSigningRequest";
     private final static String DisplayName = "Submit SignPath Signing Request";
 
+    @Deprecated
     private String organizationId;
     private String projectSlug;
     private String artifactConfigurationSlug;
@@ -53,8 +55,8 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
         boolean waitForCompletion = getWaitForCompletion();
         String outputArtifactPath = waitForCompletion ? ensureNotNull(getOutputArtifactPath(), "outputArtifactPath") : null;
         SubmitSigningRequestStepInput input = new SubmitSigningRequestStepInput(
-                ensureValidUUID(getOrganizationIdWithGlobalConfig(), "organizationId"),
-                ensureNotNull(getTrustedBuildSystemTokenCredentialId(), "trustedBuildSystemTokenCredentialId"),
+                ensureValidUUID(getOrganizationIdWithGlobal(), "organizationId"),
+                ensureNotNull(getTrustedBuildSystemTokenCredentialIdWithGlobal(), "trustedBuildSystemTokenCredentialId"),
                 ensureNotNull(getApiTokenCredentialId(), "apiTokenCredentialId"),
                 ensureNotNull(getProjectSlug(), "projectSlug"),
                 getArtifactConfigurationSlug(),
@@ -106,10 +108,11 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
         return organizationId;
     }
 
-    // we use this method in the task to avoid overriding empty values at build level
-    // with the values from the global configuration
-    public String getOrganizationIdWithGlobalConfig() {
-        return getWithGlobalConfig(organizationId, SignPathPluginGlobalConfiguration::getDefaultOrganizationId);
+    public String getOrganizationIdWithGlobal() throws SignPathStepInvalidArgumentException {
+        return getWithGlobalConfig(
+            organizationId,
+            SignPathPluginGlobalConfiguration::getTrustedBuildSystemCredentialId,
+            "organizationId");
     }
 
     public String getProjectSlug() {

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
@@ -10,9 +10,6 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import io.jenkins.plugins.signpath.ApiIntegration.ApiConfiguration;
 import io.jenkins.plugins.signpath.Exceptions.SignPathStepInvalidArgumentException;
-import jenkins.model.GlobalConfiguration;
-
-import org.apache.http.annotation.Obsolete;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
@@ -22,7 +19,6 @@ import org.kohsuke.stapler.DataBoundSetter;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 
 /**
  * Represents the submitSigningRequestStep step that is executable via pipeline-script
@@ -34,7 +30,6 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
     private final static String FunctionName = "submitSigningRequest";
     private final static String DisplayName = "Submit SignPath Signing Request";
 
-    @Deprecated
     private String organizationId;
     private String projectSlug;
     private String artifactConfigurationSlug;
@@ -69,6 +64,8 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
 
         ApiConfiguration apiConfiguration = getAndValidateApiConfiguration();
         SignPathContainer container = SignPathContainer.build(context, apiConfiguration);
+
+        CheckDeprecatedParametersUsage(container);
 
         return new SubmitSigningRequestStepExecution(input,
                 container.getSecretRetriever(),
@@ -190,5 +187,19 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
     @DataBoundSetter
     public void setParameters (Map<String, String> parameters) {
         this.parameters = parameters;
+    }
+
+    private void CheckDeprecatedParametersUsage(SignPathContainer container) {
+        if (this.getApiUrl() != null && !this.getApiUrl().isEmpty()) {
+            logStepParameterDeprecationWarning(container.getTaskListener(), "apiUrl", "Api URL");
+        }
+        
+        if(this.getTrustedBuildSystemTokenCredentialId() != null && !this.getTrustedBuildSystemTokenCredentialId().isEmpty()) {
+            logStepParameterDeprecationWarning(container.getTaskListener(), "trustedBuildSystemTokenCredentialId", "Trusted Build System Credential ID");
+        }
+
+        if(this.getOrganizationId() != null && !this.getOrganizationId().isEmpty()) {
+            logStepParameterDeprecationWarning(container.getTaskListener(), "organizationId", "Organization ID");
+        }
     }
 }

--- a/src/main/resources/io/jenkins/plugins/signpath/SignPathPluginGlobalConfiguration/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/signpath/SignPathPluginGlobalConfiguration/config.jelly
@@ -7,7 +7,7 @@
     <f:entry title="${%Trusted Build System Credential ID}" field="trustedBuildSystemCredentialId">
       <f:textbox />
     </f:entry>
-    <f:entry title="${%Default Organization ID}" field="defaultOrganizationId">
+    <f:entry title="${%Organization ID}" field="organizationId">
       <f:textbox />
     </f:entry>
   </f:section>

--- a/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
@@ -56,6 +56,7 @@ public class GetSignedArtifactStepEndToEndTest {
         SignPathPluginGlobalConfiguration globalConfig = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
         globalConfig.setApiURL(apiUrl);
         globalConfig.setTrustedBuildSystemCredentialId(trustedBuildSystemTokenCredentialId);
+        globalConfig.setOrganizationId(organizationId);
         
         wireMockRule.stubFor(get(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId))
                 .willReturn(aResponse()
@@ -67,7 +68,12 @@ public class GetSignedArtifactStepEndToEndTest {
                         .withStatus(200)
                         .withBody(signedArtifactBytes)));
 
-        WorkflowJob workflowJob = createWorkflowJob(apiTokenCredentialId, organizationId, signingRequestId);
+        WorkflowJob workflowJob = createWorkflowJob(
+            apiUrl,
+            trustedBuildSystemTokenCredentialId,
+            apiTokenCredentialId,
+            organizationId,
+            signingRequestId);
 
         String remoteUrl = Some.url();
         BuildData buildData = new BuildData(Some.stringNonEmpty());
@@ -110,12 +116,15 @@ public class GetSignedArtifactStepEndToEndTest {
         assertTrue(run.getLog().contains("SignPathStepInvalidArgumentException"));
     }
 
-    private WorkflowJob createWorkflowJob(String apiTokenCredentialId,
+    private WorkflowJob createWorkflowJob(String apiUrl,
+                                          String trustedBuildSystemTokenCredentialId,
+                                          String apiTokenCredentialId,
                                           String organizationId,
                                           String signingRequestId) throws IOException {
         return j.createWorkflow("SignPath",
-                "getSignedArtifact(" +
+                "getSignedArtifact(apiUrl: '" + apiUrl + "', " +
                         "outputArtifactPath: 'signed.exe', " +
+                        "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
                         "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
                         "signingRequestId: '" + signingRequestId + "'," +

--- a/src/test/java/io/jenkins/plugins/signpath/SignPathPluginGlobalConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/SignPathPluginGlobalConfigurationTest.java
@@ -55,6 +55,12 @@ public class SignPathPluginGlobalConfigurationTest {
     }
 
     @Test
+    public void testDoCheckApiURL_EmptyValue() {
+        FormValidation result = config.doCheckApiURL("");
+        assertEquals("Validation should not pass for an empty value.", FormValidation.error("Api URL is required.").toString(), result.toString());
+    }
+
+    @Test
     public void testGetAndSetTrustedBuildSystemCredentialId() {
         String credentialId = "test-credential-id";
         config.setTrustedBuildSystemCredentialId(credentialId);
@@ -83,29 +89,35 @@ public class SignPathPluginGlobalConfigurationTest {
     }
 
     @Test
-    public void testGetAndSetDefaultOrganizationId() {
-        String organizationId = "123e4567-e89b-12d3-a456-426614174000"; 
-        config.setDefaultOrganizationId(organizationId);
-        assertEquals("The default organization ID should match the set value.", organizationId, config.getDefaultOrganizationId());
+    public void testDoCheckTrustedBuildSystemCredentialId_EmptyValue() {
+        FormValidation result = config.doCheckTrustedBuildSystemCredentialId("");
+        assertEquals("Validation should not pass for an empty value.", FormValidation.error("Trusted Build System Credential ID is required.").toString(), result.toString());
     }
 
     @Test
-    public void testDoCheckDefaultOrganizationId_ValidUUID() {
+    public void testGetAndSetOrganizationId() {
+        String organizationId = "123e4567-e89b-12d3-a456-426614174000"; 
+        config.setOrganizationId(organizationId);
+        assertEquals("The organization ID should match the set value.", organizationId, config.getOrganizationId());
+    }
+
+    @Test
+    public void testDoCheckOrganizationId_ValidUUID() {
         String validUUID = "123e4567-e89b-12d3-a456-426614174000";
-        FormValidation result = config.doCheckDefaultOrganizationId(validUUID);
+        FormValidation result = config.doCheckOrganizationId(validUUID);
         assertEquals("Validation should pass for a valid UUID.", FormValidation.ok(), result);
     }
 
     @Test
-    public void testDoCheckDefaultOrganizationId_InvalidUUID() {
+    public void testDoCheckOrganizationId_InvalidUUID() {
         String invalidUUID = "invalid-uuid";
-        FormValidation result = config.doCheckDefaultOrganizationId(invalidUUID);
-        assertEquals("Validation should fail for an invalid UUID.", FormValidation.error("Default Organization ID must be a valid uuid.").toString(), result.toString());
+        FormValidation result = config.doCheckOrganizationId(invalidUUID);
+        assertEquals("Validation should fail for an invalid UUID.", FormValidation.error("Organization ID must be a valid uuid.").toString(), result.toString());
     }
 
     @Test
-    public void testDoCheckDefaultOrganizationId_EmptyValue() {
-        FormValidation result = config.doCheckDefaultOrganizationId("");
-        assertEquals("Validation should pass for an empty value.", FormValidation.ok(), result);
+    public void testDoCheckOrganizationId_EmptyValue() {
+        FormValidation result = config.doCheckOrganizationId("");
+        assertEquals("Validation should not pass for an empty value.", FormValidation.error("Organization ID is required.").toString(), result.toString());
     }
 }

--- a/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
@@ -94,8 +94,8 @@ public class SubmitSigningRequestStepEndToEndTest {
         globalConfig.setApiURL(apiUrl);
         globalConfig.setTrustedBuildSystemCredentialId(trustedBuildSystemTokenCredentialId);
         WorkflowJob workflowJob = withOptionalFields
-                ? createWorkflowJobWithOptionalParameters(apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, userDefinedParamName, userDefinedParamValue, true)
-                : createWorkflowJob(apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, true);
+                ? createWorkflowJobWithOptionalParameters(apiUrl, trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, userDefinedParamName, userDefinedParamValue, true)
+                : createWorkflowJob(apiUrl, trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, true);
 
         String remoteUrl = Some.url();
         BuildData buildData = new BuildData(Some.stringNonEmpty());


### PR DESCRIPTION
Re-introduced the ApiUrl parameter and TBS Token Credential ID in the pipeline steps
Made all three global fields (ApiUrl, TBS Credential ID, Org Id) required
If the step-provided values do not match the global ones, fail with an error message

### Testing done
Tested the following cases:
- Fields are not set neither at the global level nor at the pipeline level.  
- Fields are set only at the global level.  
- Fields are set only at the pipeline level.  
- Fields are set at both levels, and the pipeline-level values are identical to the global-level values.  
- Fields are set at both levels, but the pipeline-level values differ from the global-level values.  

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

