### PR TITLE
Update the SignPath client to a version that sends the 'Allow Ignore Origin' header.

### DIFF
--- a/build-trigger
+++ b/build-trigger
@@ -1,4 +1,4 @@
 We use this file as a trigger for the Jenkins plugin build pipeline.
 If you want to trigger a new build, just modify it.
 
-Version - 2
+Version - 3

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>io.signpath.javaclient</groupId>
             <artifactId>api-client</artifactId>
-            <version>1.0.9</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>${revision}.${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
-        <revision>3.0.1</revision>
+        <revision>3.1.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <jenkins.baseline>2.361</jenkins.baseline> 
         <jenkins.version>${jenkins.baseline}.4</jenkins.version>

--- a/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacadeFactory.java
+++ b/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacadeFactory.java
@@ -4,6 +4,7 @@ import io.jenkins.plugins.signpath.ApiIntegration.ApiConfiguration;
 import io.jenkins.plugins.signpath.ApiIntegration.SignPathCredentials;
 import io.jenkins.plugins.signpath.ApiIntegration.SignPathFacade;
 import io.jenkins.plugins.signpath.ApiIntegration.SignPathFacadeFactory;
+import io.signpath.signpathclient.SignPathClientSimpleLogger;
 
 import java.io.PrintStream;
 
@@ -12,9 +13,9 @@ import java.io.PrintStream;
  */
 public class SignPathClientFacadeFactory implements SignPathFacadeFactory {
     private final ApiConfiguration apiConfiguration;
-    private final PrintStream logger;
+    private final SignPathClientSimpleLogger logger;
 
-    public SignPathClientFacadeFactory(ApiConfiguration apiConfiguration, PrintStream logger) {
+    public SignPathClientFacadeFactory(ApiConfiguration apiConfiguration, SignPathClientSimpleLogger logger) {
         this.apiConfiguration = apiConfiguration;
         this.logger = logger;
     }

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathClientLogger.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathClientLogger.java
@@ -1,0 +1,26 @@
+package io.jenkins.plugins.signpath;
+
+import java.io.PrintStream;
+
+import io.signpath.signpathclient.SignPathClientSimpleLogger;
+
+public class SignPathClientLogger implements SignPathClientSimpleLogger {
+    private final PrintStream printStream;
+
+    public SignPathClientLogger(PrintStream printStream) {
+        this.printStream = printStream;
+    }
+
+    @Override
+    public void log(String message, Throwable ex) {
+        printStream.println(message);
+        if(ex != null) {
+            ex.printStackTrace(this.printStream);
+        }
+    }
+
+    @Override
+    public void log(String message) {
+        printStream.println(message);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathContainer.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathContainer.java
@@ -13,6 +13,7 @@ import io.jenkins.plugins.signpath.OriginRetrieval.GitOriginRetriever;
 import io.jenkins.plugins.signpath.OriginRetrieval.OriginRetriever;
 import io.jenkins.plugins.signpath.SecretRetrieval.CredentialBasedSecretRetriever;
 import io.jenkins.plugins.signpath.SecretRetrieval.SecretRetriever;
+import io.signpath.signpathclient.SignPathClientSimpleLogger;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
@@ -87,7 +88,7 @@ public class SignPathContainer {
         assert listener != null;
         Run<?, ?> run = context.get(Run.class);
         Launcher launcher = context.get(Launcher.class);
-        PrintStream logger = listener.getLogger();
+        SignPathClientSimpleLogger logger = new SignPathClientLogger(listener.getLogger());
         Jenkins jenkins = Jenkins.get();
         FingerprintMap fingerprintMap = jenkins.getFingerprintMap();
         JenkinsLocationConfiguration config = JenkinsLocationConfiguration.get();

--- a/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
@@ -95,7 +95,7 @@ public class GetSignedArtifactStepEndToEndTest {
         assertArrayEquals(signedArtifactBytes, signedArtifactContent);
 
         wireMockRule.verify(getRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId))
-                .withHeader("Authorization", equalTo("Bearer " + apiToken + ":" + trustedBuildSystemToken)));
+                .withHeader("Authorization", equalTo("Bearer " + apiToken)));
     }
 
     @Theory


### PR DESCRIPTION
### Testing done
Tested creating a signing request for an organization where the 'Ignore Origin' subscription feature is enabled. The signing request was successfully created, and the origin information was not displayed on the SignPath UI, as expected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

