### PR TITLE
Feature/sign 7910

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.signpath.javaclient</groupId>
             <artifactId>api-client</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,17 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <name>Central Portal Snapshots</name>
+            <id>central-portal-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>io.signpath.javaclient</groupId>
             <artifactId>api-client</artifactId>
-            <version>2.1.0</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -125,6 +125,18 @@
         <repository>
             <id>repo1.maven.org</id>
             <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+            <id>ossrh-snapshots</id>
+            <name>OSSRH Snapshots</name>
+
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
     <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>${revision}.${changelist}</version>
     <packaging>hpi</packaging>
     <properties>
-        <revision>3.1.0</revision>
+        <revision>3.2.0</revision>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <changelist>${maven.build.timestamp}-SNAPSHOT</changelist>
         <jenkins.baseline>2.361</jenkins.baseline> 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,8 @@
     <packaging>hpi</packaging>
     <properties>
         <revision>3.1.0</revision>
-        <changelist>999999-SNAPSHOT</changelist>
+        <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
+        <changelist>${maven.build.timestamp}-SNAPSHOT</changelist>
         <jenkins.baseline>2.361</jenkins.baseline> 
         <jenkins.version>${jenkins.baseline}.4</jenkins.version>
         <java.level>11</java.level>

--- a/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
+++ b/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
@@ -45,7 +45,7 @@ public class SignPathClientFacade implements SignPathFacade {
                 apiConfiguration.getWaitForCompletionTimeoutInSeconds(),
                 apiConfiguration.getWaitBetweenReadinessChecksInSeconds(),
                 buildUserAgent()
-            ));
+            ), apiConfiguration.getServiceUnavailableTimeoutInSeconds());
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
@@ -30,7 +30,7 @@ public abstract class SignPathStepBase extends Step {
     private int serviceUnavailableTimeoutInSeconds = (int) TimeUnit.MINUTES.toSeconds(10);
     private int uploadAndDownloadRequestTimeoutInSeconds = (int) TimeUnit.MINUTES.toSeconds(5);
     private int waitForCompletionTimeoutInSeconds = (int) TimeUnit.MINUTES.toSeconds(10);
-    private int waitBetweenReadinessChecksInSeconds = (int) TimeUnit.SECONDS.toSeconds(30);
+    private int waitBetweenReadinessChecksInSeconds = (int) TimeUnit.SECONDS.toSeconds(5);
 
     // we set a sane default for the PowerShell call - 30min is pretty long for most customers already
     // if the customer ever runs into the problem that it is too short he will clearly see the exception


### PR DESCRIPTION
* Update the SignPath client library, which includes improvements in the retry mechanism and error reporting/logging
* Decrease the backoff period when polling the status of Signing Request from 30 to 5 seconds, which should improve the overall performance

### Testing done

<!-- Comment:
Regression tested on a local Jenkins Server
-->
