### PR TITLE
SIGN-8475 Jenkins Cleanup

### DIFF
--- a/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
+++ b/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
@@ -139,14 +139,7 @@ public class SignPathClientFacade implements SignPathFacade {
         TemporaryFile outputArtifact = new TemporaryFile();
 
         try {
-            SigningRequestStatusResponse request = client.waitForFinalSigningRequestStatus(
-                credentials.getApiToken().getPlainText(),
-                organizationId.toString(),
-                signingRequestID.toString());
-
-            if(!request.isFinalStatus()) {
-                throw new SignPathFacadeCallException("Timeout expired while waiting for signing request to complete");
-            }
+            waitForFinalSigningRequestStatus(organizationId, signingRequestID);
 
             client.downloadSignedArtifact(
                     credentials.getApiToken().getPlainText(),

--- a/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
+++ b/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathClient/SignPathClientFacade.java
@@ -119,6 +119,22 @@ public class SignPathClientFacade implements SignPathFacade {
     }
 
     @Override
+    public void waitForFinalSigningRequestStatus(UUID organizationId, UUID signingRequestId) throws SignPathFacadeCallException {
+        try {
+            SigningRequestStatusResponse statusResponse = client.waitForFinalSigningRequestStatus(
+                    credentials.getApiToken().getPlainText(),
+                    organizationId.toString(),
+                    signingRequestId.toString());
+            if (!statusResponse.isFinalStatus()) {
+                throw new SignPathFacadeCallException("Timeout expired while waiting for signing request to complete");
+            }
+        } catch (SignPathClientException ex) {
+            Logger.getLogger(SignPathClientFacade.class.getName()).log(Level.SEVERE, null, ex);
+            throw new SignPathFacadeCallException(ex.getMessage());
+        }
+    }
+
+    @Override
     public TemporaryFile getSignedArtifact(UUID organizationId, UUID signingRequestID) throws IOException, SignPathFacadeCallException {
         TemporaryFile outputArtifact = new TemporaryFile();
 

--- a/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathFacade.java
+++ b/src/main/java/io/jenkins/plugins/signpath/ApiIntegration/SignPathFacade.java
@@ -49,6 +49,15 @@ public interface SignPathFacade {
     void uploadUnsignedArtifact(String uploadLink, InputStream artifactStream) throws IOException, SignPathFacadeCallException;
 
     /**
+     * Waits for a signing request to reach a final status without downloading the artifact.
+     *
+     * @param organizationId   the organization ID where the signing request resides
+     * @param signingRequestId the signing request ID as returned by submitSigningRequest
+     * @throws SignPathFacadeCallException occurs if the request fails or times out
+     */
+    void waitForFinalSigningRequestStatus(UUID organizationId, UUID signingRequestId) throws SignPathFacadeCallException;
+
+    /**
      * Downloads a signed artifact from SignPath
      *
      * @param organizationId   the organization ID where the signing request resides

--- a/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStep.java
+++ b/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStep.java
@@ -51,7 +51,6 @@ public class GetSignedArtifactStep extends SignPathStepBase {
         SignPathContainer container = SignPathContainer.build(context, apiConfiguration);
         return new GetSignedArtifactStepExecution(input,
                 container.getSecretRetriever(),
-                container.getArtifactFileManager(),
                 container.getSignPathFacadeFactory(),
                 container.getTaskListener(),
                 container.getStepContext());

--- a/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/signpath/GetSignedArtifactStepExecution.java
@@ -1,12 +1,12 @@
 package io.jenkins.plugins.signpath;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import hudson.FilePath;
 import hudson.model.TaskListener;
 import hudson.util.Secret;
 import io.jenkins.plugins.signpath.ApiIntegration.SignPathCredentials;
 import io.jenkins.plugins.signpath.ApiIntegration.SignPathFacade;
 import io.jenkins.plugins.signpath.ApiIntegration.SignPathFacadeFactory;
-import io.jenkins.plugins.signpath.Artifacts.ArtifactFileManager;
 import io.jenkins.plugins.signpath.Common.TemporaryFile;
 import io.jenkins.plugins.signpath.Exceptions.SecretNotFoundException;
 import io.jenkins.plugins.signpath.Exceptions.SignPathFacadeCallException;
@@ -15,9 +15,10 @@ import io.jenkins.plugins.signpath.SecretRetrieval.SecretRetriever;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
-import java.security.NoSuchAlgorithmException;
 
 /**
  * The step-execution for the
@@ -29,20 +30,17 @@ public class GetSignedArtifactStepExecution extends SynchronousNonBlockingStepEx
     // If we want to support resuming, we need to remove 'transient' and make sure everything is serializable
     private transient final GetSignedArtifactStepInput input;
     private transient final SecretRetriever secretRetriever;
-    private transient final ArtifactFileManager artifactFileManager;
     private transient final SignPathFacadeFactory signPathFacadeFactory;
     private transient final TaskListener taskListener;
 
     protected GetSignedArtifactStepExecution(GetSignedArtifactStepInput input,
                                              SecretRetriever secretRetriever,
-                                             ArtifactFileManager artifactFileManager,
                                              SignPathFacadeFactory signPathFacadeFactory,
                                              TaskListener taskListener,
                                              StepContext stepContext) {
         super(stepContext);
         this.input = input;
         this.secretRetriever = secretRetriever;
-        this.artifactFileManager = artifactFileManager;
         this.signPathFacadeFactory = signPathFacadeFactory;
         this.taskListener = taskListener;
     }
@@ -54,15 +52,25 @@ public class GetSignedArtifactStepExecution extends SynchronousNonBlockingStepEx
         logger.printf("Downloading signed artifact for organization: %s and signingRequest: %s%n", input.getOrganizationId(), input.getSigningRequestId());
 
         try {
+            FilePath workspace = getContext().get(FilePath.class);
+            if (workspace == null) {
+                throw new IOException("Could not obtain workspace from step context.");
+            }
+
             Secret trustedBuildSystemToken = secretRetriever.retrieveSecret(input.getTrustedBuildSystemTokenCredentialId());
             Secret apiToken = secretRetriever.retrieveSecret(input.getApiTokenCredentialId(), new CredentialsScope[] { CredentialsScope.SYSTEM, CredentialsScope.GLOBAL });
             SignPathCredentials credentials = new SignPathCredentials(apiToken, trustedBuildSystemToken);
             SignPathFacade signPathFacade = signPathFacadeFactory.create(credentials);
+            // signedArtifact is a temporary download buffer on the controller, the try block ensures it is
+            // cleaned up after its contents are copied to the persistent workspace file at outputArtifactPath.
             try (TemporaryFile signedArtifact = signPathFacade.getSignedArtifact(input.getOrganizationId(), input.getSigningRequestId())) {
-                artifactFileManager.storeArtifact(signedArtifact, input.getOutputArtifactPath());
+                FilePath outputPath = workspace.child(input.getOutputArtifactPath());
+                try (InputStream in = new FileInputStream(signedArtifact.getFile())) {
+                    outputPath.copyFrom(in);
+                }
                 logger.println("Downloading signed artifact succeeded");
             }
-        } catch (SecretNotFoundException | SignPathFacadeCallException | IOException | InterruptedException | NoSuchAlgorithmException ex) {
+        } catch (SecretNotFoundException | SignPathFacadeCallException | IOException | InterruptedException ex) {
             logger.printf("Downloading signed artifact failed %s%n", ex.getMessage());
             throw new SignPathStepFailedException("Downloading signed artifact failed: " + ex.getMessage(), ex);
         }

--- a/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SignPathStepBase.java
@@ -4,14 +4,10 @@ import io.jenkins.plugins.signpath.ApiIntegration.ApiConfiguration;
 import io.jenkins.plugins.signpath.Common.PluginConstants;
 import io.jenkins.plugins.signpath.Exceptions.SignPathStepInvalidArgumentException;
 import jenkins.model.GlobalConfiguration;
-import jenkins.model.Jenkins;
 
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import hudson.model.TaskListener;
-
-import java.io.PrintStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.UUID;
@@ -32,20 +28,8 @@ public abstract class SignPathStepBase extends Step {
     private int waitForCompletionTimeoutInSeconds = (int) TimeUnit.MINUTES.toSeconds(10);
     private int waitBetweenReadinessChecksInSeconds = (int) TimeUnit.SECONDS.toSeconds(5);
 
-    private String apiUrl;
     private String trustedBuildSystemTokenCredentialId;
     private String apiTokenCredentialId = PluginConstants.DEFAULT_API_TOKEN_CREDENTIAL_ID;
-
-    public String getApiUrl() {
-        return apiUrl;
-    }
-
-    public String getApiUrlWithGlobal() throws SignPathStepInvalidArgumentException {
-        return getWithGlobalConfig(
-            apiUrl,
-            SignPathPluginGlobalConfiguration::getApiURL,
-            "apiUrl", false);
-    }
 
     public String getTrustedBuildSystemTokenCredentialId() {
         return trustedBuildSystemTokenCredentialId;
@@ -79,11 +63,6 @@ public abstract class SignPathStepBase extends Step {
     }
 
     @DataBoundSetter
-    public void setApiUrl(String apiUrl) {
-        this.apiUrl = apiUrl;
-    }
-
-    @DataBoundSetter
     public void setTrustedBuildSystemTokenCredentialId(String trustedBuildSystemTokenCredentialId) {
         this.trustedBuildSystemTokenCredentialId = trustedBuildSystemTokenCredentialId;
     }
@@ -109,8 +88,12 @@ public abstract class SignPathStepBase extends Step {
     }
 
     public ApiConfiguration getAndValidateApiConfiguration() throws SignPathStepInvalidArgumentException {
+        String apiUrl = getSignPathConfig().getApiURL();
+        if (apiUrl == null || apiUrl.isEmpty()) {
+            throw new SignPathStepInvalidArgumentException("apiUrl must be configured in Jenkins system configuration under 'Code Signing with SignPath'");
+        }
         return new ApiConfiguration(
-                ensureValidURL(getApiUrlWithGlobal()),
+                ensureValidURL(apiUrl),
                 getServiceUnavailableTimeoutInSeconds(),
                 getUploadAndDownloadRequestTimeoutInSeconds(),
                 getWaitForCompletionTimeoutInSeconds(),
@@ -162,17 +145,6 @@ public abstract class SignPathStepBase extends Step {
 
         // here it doesn't matter which value we return, as they are identical
         return stepLevelValue;
-    }
-
-    protected void logStepParameterDeprecationWarning(TaskListener listener, String parameterName, String globalConfigName) {
-        listener
-            .getLogger()
-            .println(
-                String.format(
-                    "WARNING: The '%s' parameter is deprecated and will be removed in a future release." +
-                    " Please use Jenkins system configuration 'Code Signing with SignPath'->'%s' instead.",
-                    parameterName,
-                    globalConfigName));
     }
 
     protected URL ensureValidURL(String apiUrl) throws SignPathStepInvalidArgumentException {

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
@@ -37,7 +37,6 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
     private String inputArtifactPath;
     private String description;
     private boolean waitForCompletion = false;
-    private String outputArtifactPath;
     private Map<String, String> parameters;
     private String inputArtifactRetrievalUrl;
     private Map<String, String> inputArtifactRetrievalHttpHeaders;
@@ -49,9 +48,6 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
 
     @Override
     public StepExecution start(StepContext context) throws IOException, InterruptedException, SignPathStepInvalidArgumentException {
-        boolean waitForCompletion = getWaitForCompletion();
-        String outputArtifactPath = waitForCompletion ? ensureNotNull(getOutputArtifactPath(), "outputArtifactPath") : null;
-
         if (getInputArtifactRetrievalHttpHeaders() != null && !getInputArtifactRetrievalHttpHeaders().isEmpty()
                 && (getInputArtifactRetrievalUrl() == null || getInputArtifactRetrievalUrl().isEmpty())) {
             throw new SignPathStepInvalidArgumentException("inputArtifactRetrievalHttpHeaders can only be provided together with inputArtifactRetrievalUrl");
@@ -66,16 +62,13 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
                 ensureNotNull(getSigningPolicySlug(), "signingPolicySlug"),
                 ensureNotNull(getInputArtifactPath(), "inputArtifactPath"),
                 getDescription(),
-                outputArtifactPath,
                 getParameters(),
-                waitForCompletion,
+                getWaitForCompletion(),
                 getInputArtifactRetrievalUrl(),
                 getInputArtifactRetrievalHttpHeaders());
 
         ApiConfiguration apiConfiguration = getAndValidateApiConfiguration();
         SignPathContainer container = SignPathContainer.build(context, apiConfiguration);
-
-        CheckDeprecatedParametersUsage(container);
 
         return new SubmitSigningRequestStepExecution(input,
                 container.getSecretRetriever(),
@@ -146,10 +139,6 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
         return waitForCompletion;
     }
 
-    public String getOutputArtifactPath() {
-        return outputArtifactPath;
-    }
-    
     public Map<String, String> getParameters () {
         return parameters;
     }
@@ -198,11 +187,6 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
     }
 
     @DataBoundSetter
-    public void setOutputArtifactPath(String outputArtifactPath) {
-        this.outputArtifactPath = outputArtifactPath;
-    }
-    
-    @DataBoundSetter
     public void setParameters (Map<String, String> parameters) {
         this.parameters = parameters;
     }
@@ -217,9 +201,4 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
         this.inputArtifactRetrievalHttpHeaders = inputArtifactRetrievalHttpHeaders;
     }
 
-    private void CheckDeprecatedParametersUsage(SignPathContainer container) {
-        if (this.getApiUrl() != null && !this.getApiUrl().isEmpty()) {
-            logStepParameterDeprecationWarning(container.getTaskListener(), "apiUrl", "Api URL");
-        }
-    }
 }

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStep.java
@@ -36,6 +36,7 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
     private String signingPolicySlug;
     private String inputArtifactPath;
     private String description;
+    private String outputArtifactPath;
     private boolean waitForCompletion = false;
     private Map<String, String> parameters;
     private String inputArtifactRetrievalUrl;
@@ -48,6 +49,10 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
 
     @Override
     public StepExecution start(StepContext context) throws IOException, InterruptedException, SignPathStepInvalidArgumentException {
+        if (getOutputArtifactPath() != null && !getOutputArtifactPath().isEmpty() && !getWaitForCompletion()) {
+            throw new SignPathStepInvalidArgumentException("outputArtifactPath can only be set if waitForCompletion is true");
+        }
+
         if (getInputArtifactRetrievalHttpHeaders() != null && !getInputArtifactRetrievalHttpHeaders().isEmpty()
                 && (getInputArtifactRetrievalUrl() == null || getInputArtifactRetrievalUrl().isEmpty())) {
             throw new SignPathStepInvalidArgumentException("inputArtifactRetrievalHttpHeaders can only be provided together with inputArtifactRetrievalUrl");
@@ -62,6 +67,7 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
                 ensureNotNull(getSigningPolicySlug(), "signingPolicySlug"),
                 ensureNotNull(getInputArtifactPath(), "inputArtifactPath"),
                 getDescription(),
+                getOutputArtifactPath(),
                 getParameters(),
                 getWaitForCompletion(),
                 getInputArtifactRetrievalUrl(),
@@ -135,6 +141,10 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
         return description;
     }
 
+    public String getOutputArtifactPath() {
+        return outputArtifactPath;
+    }
+
     public boolean getWaitForCompletion() {
         return waitForCompletion;
     }
@@ -179,6 +189,11 @@ public class SubmitSigningRequestStep extends SignPathStepBase {
     @DataBoundSetter
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    @DataBoundSetter
+    public void setOutputArtifactPath(String outputArtifactPath) {
+        this.outputArtifactPath = outputArtifactPath;
     }
 
     @DataBoundSetter

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepExecution.java
@@ -172,19 +172,24 @@ public class SubmitSigningRequestStepExecution extends SynchronousNonBlockingSte
                     logger.println("WARNING: Signing request URL was not provided by the server.");
                 }
 
-                if (input.getWaitForCompletion()) {
-                    if (input.hasOutputArtifactPath()) {
-                        // signedArtifact is a temporary download buffer on the controller, the try block ensures it is
-                        // cleaned up after its contents are copied to the persistent workspace file at outputArtifactPath.
-                        try (TemporaryFile signedArtifact = signPathFacade.getSignedArtifact(input.getOrganizationId(), signingRequestId)) {
-                            FilePath outputPath = workspace.child(input.getOutputArtifactPath());
-                            try (InputStream signedArtifactStream = new FileInputStream(signedArtifact.getFile())) {
-                                outputPath.copyFrom(signedArtifactStream);
-                            }
+                // waitForFinalSigningRequestStatus is skipped when outputArtifactPath is set because
+                // getSignedArtifact below already waits for the final status internally.
+                if (input.getWaitForCompletion() && !input.hasOutputArtifactPath()) {
+                    signPathFacade.waitForFinalSigningRequestStatus(input.getOrganizationId(), signingRequestId);
+                }
+
+                if (input.hasOutputArtifactPath()) {
+                    // signedArtifact is a temporary download buffer on the controller, the try block ensures it is
+                    // cleaned up after its contents are copied to the persistent workspace file at outputArtifactPath.
+                    try (TemporaryFile signedArtifact = signPathFacade.getSignedArtifact(input.getOrganizationId(), signingRequestId)) {
+                        FilePath outputPath = workspace.child(input.getOutputArtifactPath());
+                        try (InputStream signedArtifactStream = new FileInputStream(signedArtifact.getFile())) {
+                            outputPath.copyFrom(signedArtifactStream);
                         }
-                    } else {
-                        signPathFacade.waitForFinalSigningRequestStatus(input.getOrganizationId(), signingRequestId);
                     }
+                }
+
+                if (input.getWaitForCompletion()) {
                     logger.println("Signing step succeeded");
                 }
 

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepExecution.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
@@ -173,8 +174,13 @@ public class SubmitSigningRequestStepExecution extends SynchronousNonBlockingSte
 
                 if (input.getWaitForCompletion()) {
                     if (input.hasOutputArtifactPath()) {
+                        // signedArtifact is a temporary download buffer on the controller, the try block ensures it is
+                        // cleaned up after its contents are copied to the persistent workspace file at outputArtifactPath.
                         try (TemporaryFile signedArtifact = signPathFacade.getSignedArtifact(input.getOrganizationId(), signingRequestId)) {
-                            artifactFileManager.storeArtifact(signedArtifact, input.getOutputArtifactPath());
+                            FilePath outputPath = workspace.child(input.getOutputArtifactPath());
+                            try (InputStream signedArtifactStream = new FileInputStream(signedArtifact.getFile())) {
+                                outputPath.copyFrom(signedArtifactStream);
+                            }
                         }
                     } else {
                         signPathFacade.waitForFinalSigningRequestStatus(input.getOrganizationId(), signingRequestId);

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepExecution.java
@@ -172,7 +172,13 @@ public class SubmitSigningRequestStepExecution extends SynchronousNonBlockingSte
                 }
 
                 if (input.getWaitForCompletion()) {
-                    signPathFacade.waitForFinalSigningRequestStatus(input.getOrganizationId(), signingRequestId);
+                    if (input.hasOutputArtifactPath()) {
+                        try (TemporaryFile signedArtifact = signPathFacade.getSignedArtifact(input.getOrganizationId(), signingRequestId)) {
+                            artifactFileManager.storeArtifact(signedArtifact, input.getOutputArtifactPath());
+                        }
+                    } else {
+                        signPathFacade.waitForFinalSigningRequestStatus(input.getOrganizationId(), signingRequestId);
+                    }
                     logger.println("Signing step succeeded");
                 }
 

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepExecution.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepExecution.java
@@ -172,9 +172,7 @@ public class SubmitSigningRequestStepExecution extends SynchronousNonBlockingSte
                 }
 
                 if (input.getWaitForCompletion()) {
-                    try (TemporaryFile signedArtifact = signPathFacade.getSignedArtifact(input.getOrganizationId(), signingRequestId)) {
-                        artifactFileManager.storeArtifact(signedArtifact, input.getOutputArtifactPath());
-                    }
+                    signPathFacade.waitForFinalSigningRequestStatus(input.getOrganizationId(), signingRequestId);
                     logger.println("Signing step succeeded");
                 }
 

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepInput.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepInput.java
@@ -20,6 +20,7 @@ public class SubmitSigningRequestStepInput implements Serializable {
     private final String signingPolicySlug;
     private final String inputArtifactPath;
     private final String description;
+    private final String outputArtifactPath;
     private final boolean waitForCompletion;
     private final Map<String, String> parameters;
     private final String inputArtifactRetrievalUrl;
@@ -33,6 +34,7 @@ public class SubmitSigningRequestStepInput implements Serializable {
                                          String signingPolicySlug,
                                          String inputArtifactPath,
                                          String description,
+                                         String outputArtifactPath,
                                          Map<String, String> parameters,
                                          boolean waitForCompletion,
                                          String inputArtifactRetrievalUrl,
@@ -45,6 +47,7 @@ public class SubmitSigningRequestStepInput implements Serializable {
         this.signingPolicySlug = signingPolicySlug;
         this.inputArtifactPath = inputArtifactPath;
         this.description = description;
+        this.outputArtifactPath = outputArtifactPath;
         this.parameters = parameters;
         this.waitForCompletion = waitForCompletion;
         this.inputArtifactRetrievalUrl = inputArtifactRetrievalUrl;
@@ -85,6 +88,14 @@ public class SubmitSigningRequestStepInput implements Serializable {
 
     public String getDescription() {
         return description;
+    }
+
+    public String getOutputArtifactPath() {
+        return outputArtifactPath;
+    }
+
+    public boolean hasOutputArtifactPath() {
+        return outputArtifactPath != null && !outputArtifactPath.isEmpty();
     }
 
     public Map<String, String> getParameters() {

--- a/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepInput.java
+++ b/src/main/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepInput.java
@@ -20,7 +20,6 @@ public class SubmitSigningRequestStepInput implements Serializable {
     private final String signingPolicySlug;
     private final String inputArtifactPath;
     private final String description;
-    private final String outputArtifactPath;
     private final boolean waitForCompletion;
     private final Map<String, String> parameters;
     private final String inputArtifactRetrievalUrl;
@@ -34,7 +33,6 @@ public class SubmitSigningRequestStepInput implements Serializable {
                                          String signingPolicySlug,
                                          String inputArtifactPath,
                                          String description,
-                                         String outputArtifactPath,
                                          Map<String, String> parameters,
                                          boolean waitForCompletion,
                                          String inputArtifactRetrievalUrl,
@@ -47,7 +45,6 @@ public class SubmitSigningRequestStepInput implements Serializable {
         this.signingPolicySlug = signingPolicySlug;
         this.inputArtifactPath = inputArtifactPath;
         this.description = description;
-        this.outputArtifactPath = outputArtifactPath;
         this.parameters = parameters;
         this.waitForCompletion = waitForCompletion;
         this.inputArtifactRetrievalUrl = inputArtifactRetrievalUrl;
@@ -90,10 +87,6 @@ public class SubmitSigningRequestStepInput implements Serializable {
         return description;
     }
 
-    public String getOutputArtifactPath() {
-        return outputArtifactPath;
-    }
-    
     public Map<String, String> getParameters() {
         return parameters;
     }

--- a/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.*;
 @RunWith(Theories.class)
 public class GetSignedArtifactStepEndToEndTest {
     private static final int MockServerPort = 51000;
+    private static final String SIGNED_ARTIFACT_PATH = "signed.exe";
 
     @Rule
     public final SignPathJenkinsRule j = new SignPathJenkinsRule();
@@ -117,7 +118,7 @@ public class GetSignedArtifactStepEndToEndTest {
                                           String signingRequestId) throws IOException {
         return j.createWorkflow("SignPath",
                 "getSignedArtifact(" +
-                        "outputArtifactPath: 'signed.exe', " +
+                        "outputArtifactPath: '" + SIGNED_ARTIFACT_PATH + "', " +
                         "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
                         "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
@@ -138,7 +139,7 @@ public class GetSignedArtifactStepEndToEndTest {
     private byte[] getSignedArtifactBytes(WorkflowJob workflowJob) throws IOException, InterruptedException {
         FilePath workspace = j.jenkins.getWorkspaceFor(workflowJob);
         assert workspace != null;
-        try (InputStream in = workspace.child("signed.exe").read()) {
+        try (InputStream in = workspace.child(SIGNED_ARTIFACT_PATH).read()) {
             return in.readAllBytes();
         }
     }

--- a/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
@@ -3,15 +3,10 @@ package io.jenkins.plugins.signpath;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import hudson.Launcher;
-import hudson.model.FingerprintMap;
+import hudson.FilePath;
 import hudson.model.Result;
-import hudson.model.TaskListener;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.git.util.BuildData;
-import io.jenkins.plugins.signpath.Artifacts.DefaultArtifactFileManager;
-import io.jenkins.plugins.signpath.Common.TemporaryFile;
-import io.jenkins.plugins.signpath.Exceptions.ArtifactNotFoundException;
 import io.jenkins.plugins.signpath.TestUtils.*;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -22,6 +17,7 @@ import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import jenkins.model.GlobalConfiguration;
@@ -90,7 +86,7 @@ public class GetSignedArtifactStepEndToEndTest {
             fail();
         }
 
-        byte[] signedArtifactContent = getSignedArtifactBytes(run);
+        byte[] signedArtifactContent = getSignedArtifactBytes(workflowJob);
         assertArrayEquals(signedArtifactBytes, signedArtifactContent);
 
         wireMockRule.verify(getRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId + "/Status"))
@@ -139,12 +135,11 @@ public class GetSignedArtifactStepEndToEndTest {
         return String.format("http://localhost:%d/%s", MockServerPort, postfix);
     }
 
-    private byte[] getSignedArtifactBytes(WorkflowRun run) throws IOException, ArtifactNotFoundException {
-        Launcher launcher = j.createLocalLauncher();
-        TaskListener listener = j.createTaskListener();
-        FingerprintMap fingerprintMap = j.jenkins.getFingerprintMap();
-        DefaultArtifactFileManager artifactFileManager = new DefaultArtifactFileManager(fingerprintMap, run, launcher, listener);
-        TemporaryFile signedArtifact = artifactFileManager.retrieveArtifact("signed.exe");
-        return TemporaryFileUtil.getContentAndDispose(signedArtifact);
+    private byte[] getSignedArtifactBytes(WorkflowJob workflowJob) throws IOException, InterruptedException {
+        FilePath workspace = j.jenkins.getWorkspaceFor(workflowJob);
+        assert workspace != null;
+        try (InputStream in = workspace.child("signed.exe").read()) {
+            return in.readAllBytes();
+        }
     }
 }

--- a/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/GetSignedArtifactStepEndToEndTest.java
@@ -69,7 +69,6 @@ public class GetSignedArtifactStepEndToEndTest {
                         .withBody(signedArtifactBytes)));
 
         WorkflowJob workflowJob = createWorkflowJob(
-            apiUrl,
             trustedBuildSystemTokenCredentialId,
             apiTokenCredentialId,
             organizationId,
@@ -116,13 +115,12 @@ public class GetSignedArtifactStepEndToEndTest {
         assertTrue(run.getLog().contains("SignPathStepInvalidArgumentException"));
     }
 
-    private WorkflowJob createWorkflowJob(String apiUrl,
-                                          String trustedBuildSystemTokenCredentialId,
+    private WorkflowJob createWorkflowJob(String trustedBuildSystemTokenCredentialId,
                                           String apiTokenCredentialId,
                                           String organizationId,
                                           String signingRequestId) throws IOException {
         return j.createWorkflow("SignPath",
-                "getSignedArtifact(apiUrl: '" + apiUrl + "', " +
+                "getSignedArtifact(" +
                         "outputArtifactPath: 'signed.exe', " +
                         "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
                         "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +

--- a/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
@@ -41,6 +41,9 @@ import static org.junit.Assert.*;
 @RunWith(Theories.class)
 public class SubmitSigningRequestStepEndToEndTest {
     private static final int MockServerPort = 51000;
+    private static final String UNSIGNED_ARTIFACT_PATH = "unsigned.exe";
+    private static final String SIGNED_ARTIFACT_PATH = "signed.exe";
+    private static final String SHA256_ARTIFACT_PATH = UNSIGNED_ARTIFACT_PATH + ".sha256";
 
     @Rule
     public final SignPathJenkinsRule j = new SignPathJenkinsRule();
@@ -151,16 +154,16 @@ public class SubmitSigningRequestStepEndToEndTest {
         globalConfig.setTrustedBuildSystemCredentialId(trustedBuildSystemTokenCredentialId);
 
         WorkflowJob workflowJob = j.createWorkflow("SignPath",
-                "writeFile text: '" + unsignedArtifactString + "', file: 'unsigned.exe'; " +
+                "writeFile text: '" + unsignedArtifactString + "', file: '" + UNSIGNED_ARTIFACT_PATH + "'; " +
                         "echo '<returnValue>:\"'+ submitSigningRequest(" +
-                        "inputArtifactPath: 'unsigned.exe', " +
+                        "inputArtifactPath: '" + UNSIGNED_ARTIFACT_PATH + "', " +
                         "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
                         "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
                         "projectSlug: '" + projectSlug + "'," +
                         "signingPolicySlug: '" + signingPolicySlug + "'," +
                         "waitForCompletion: true," +
-                        "outputArtifactPath: 'signed.exe'," +
+                        "outputArtifactPath: '" + SIGNED_ARTIFACT_PATH + "'," +
                         "serviceUnavailableTimeoutInSeconds: 10," +
                         "uploadAndDownloadRequestTimeoutInSeconds: 10," +
                         "waitForCompletionTimeoutInSeconds: 10) + '\"';");
@@ -309,7 +312,7 @@ public class SubmitSigningRequestStepEndToEndTest {
 
         // REVIEW: simplify and unify hashing functionality (see other comments about hashing)
         // The .sha256 file MUST be archived on Jenkins
-        TemporaryFile hashFile = artifactFileManager.retrieveArtifact("unsigned.exe.sha256");
+        TemporaryFile hashFile = artifactFileManager.retrieveArtifact(SHA256_ARTIFACT_PATH);
         byte[] hashFileContent = TemporaryFileUtil.getContentAndDispose(hashFile);
         String sha256Base64 = new String(hashFileContent, StandardCharsets.UTF_8);
 
@@ -323,7 +326,7 @@ public class SubmitSigningRequestStepEndToEndTest {
 
         // The original unsigned artifact must NOT be archived on Jenkins
         try {
-            artifactFileManager.retrieveArtifact("unsigned.exe");
+            artifactFileManager.retrieveArtifact(UNSIGNED_ARTIFACT_PATH);
             fail("Expected ArtifactNotFoundException: the original artifact should not be uploaded to Jenkins");
         } catch (ArtifactNotFoundException expected) {
             // correct: the artifact is not on Jenkins
@@ -410,16 +413,16 @@ public class SubmitSigningRequestStepEndToEndTest {
         globalConfig.setTrustedBuildSystemCredentialId(Some.stringNonEmpty());
 
         WorkflowJob workflowJob = j.createWorkflow("SignPath",
-                "writeFile text: 'content', file: 'unsigned.exe'; " +
+                "writeFile text: 'content', file: '" + UNSIGNED_ARTIFACT_PATH + "'; " +
                         "submitSigningRequest(" +
-                        "inputArtifactPath: 'unsigned.exe', " +
+                        "inputArtifactPath: '" + UNSIGNED_ARTIFACT_PATH + "', " +
                         "trustedBuildSystemTokenCredentialId: '" + Some.stringNonEmpty() + "'," +
                         "apiTokenCredentialId: '" + Some.stringNonEmpty() + "'," +
                         "organizationId: '" + Some.uuid() + "'," +
                         "projectSlug: '" + Some.stringNonEmpty() + "'," +
                         "signingPolicySlug: '" + Some.stringNonEmpty() + "'," +
                         "waitForCompletion: false," +
-                        "outputArtifactPath: 'signed.exe');");
+                        "outputArtifactPath: '" + SIGNED_ARTIFACT_PATH + "');");
 
         BuildData buildData = new BuildData(Some.stringNonEmpty());
         buildData.saveBuild(BuildDataDomainObjectMother.createRandomBuild(1));
@@ -442,9 +445,9 @@ public class SubmitSigningRequestStepEndToEndTest {
         globalConfig.setTrustedBuildSystemCredentialId(Some.stringNonEmpty());
 
         WorkflowJob workflowJob = j.createWorkflow("SignPath",
-                "writeFile text: 'content', file: 'unsigned.exe'; " +
+                "writeFile text: 'content', file: '" + UNSIGNED_ARTIFACT_PATH + "'; " +
                         "submitSigningRequest(" +
-                        "inputArtifactPath: 'unsigned.exe', " +
+                        "inputArtifactPath: '" + UNSIGNED_ARTIFACT_PATH + "', " +
                         "trustedBuildSystemTokenCredentialId: '" + Some.stringNonEmpty() + "'," +
                         "apiTokenCredentialId: '" + Some.stringNonEmpty() + "'," +
                         "organizationId: '" + Some.uuid() + "'," +
@@ -494,10 +497,10 @@ public class SubmitSigningRequestStepEndToEndTest {
         globalConfig.setTrustedBuildSystemCredentialId(Some.stringNonEmpty());
 
         WorkflowJob workflowJob = j.createWorkflow("SignPath",
-                "writeFile text: 'content', file: 'unsigned.exe'; " +
+                "writeFile text: 'content', file: '" + UNSIGNED_ARTIFACT_PATH + "'; " +
                         "submitSigningRequest(" +
                         "apiUrl: '" + getMockUrl() + "'," +
-                        "inputArtifactPath: 'unsigned.exe'," +
+                        "inputArtifactPath: '" + UNSIGNED_ARTIFACT_PATH + "'," +
                         "trustedBuildSystemTokenCredentialId: '" + Some.stringNonEmpty() + "'," +
                         "apiTokenCredentialId: '" + Some.stringNonEmpty() + "'," +
                         "organizationId: '" + Some.uuid() + "'," +
@@ -603,9 +606,9 @@ public class SubmitSigningRequestStepEndToEndTest {
                                                                 String userDefinedParamValue,
                                                                 boolean waitForCompletion) throws IOException {
         return j.createWorkflow("SignPath",
-                "writeFile text: '" + unsignedArtifactString + "', file: 'unsigned.exe'; " +
+                "writeFile text: '" + unsignedArtifactString + "', file: '" + UNSIGNED_ARTIFACT_PATH + "'; " +
                         "echo '<returnValue>:\"'+ submitSigningRequest(" +
-                        "inputArtifactPath: 'unsigned.exe', " +
+                        "inputArtifactPath: '" + UNSIGNED_ARTIFACT_PATH + "', " +
                         "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
                         "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
@@ -628,9 +631,9 @@ public class SubmitSigningRequestStepEndToEndTest {
                                           String unsignedArtifactString,
                                           boolean waitForCompletion) throws IOException {
         return j.createWorkflow("SignPath",
-                "writeFile text: '" + unsignedArtifactString + "', file: 'unsigned.exe'; " +
+                "writeFile text: '" + unsignedArtifactString + "', file: '" + UNSIGNED_ARTIFACT_PATH + "'; " +
                         "echo '<returnValue>:\"'+ submitSigningRequest(" +
-                        "inputArtifactPath: 'unsigned.exe', " +
+                        "inputArtifactPath: '" + UNSIGNED_ARTIFACT_PATH + "', " +
                         "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
                         "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
@@ -653,9 +656,9 @@ public class SubmitSigningRequestStepEndToEndTest {
                                                                    String retrievalHeaderValue,
                                                                    boolean waitForCompletion) throws IOException {
         return j.createWorkflow("SignPath",
-                "writeFile text: '" + unsignedArtifactString + "', file: 'unsigned.exe'; " +
+                "writeFile text: '" + unsignedArtifactString + "', file: '" + UNSIGNED_ARTIFACT_PATH + "'; " +
                         "echo '<returnValue>:\"'+ submitSigningRequest(" +
-                        "inputArtifactPath: 'unsigned.exe', " +
+                        "inputArtifactPath: '" + UNSIGNED_ARTIFACT_PATH + "', " +
                         "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
                         "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
@@ -674,7 +677,7 @@ public class SubmitSigningRequestStepEndToEndTest {
     private byte[] getSignedArtifactBytes(WorkflowJob workflowJob) throws IOException, InterruptedException {
         FilePath workspace = j.jenkins.getWorkspaceFor(workflowJob);
         assert workspace != null;
-        try (InputStream in = workspace.child("signed.exe").read()) {
+        try (InputStream in = workspace.child(SIGNED_ARTIFACT_PATH).read()) {
             return in.readAllBytes();
         }
     }
@@ -685,7 +688,7 @@ public class SubmitSigningRequestStepEndToEndTest {
         FingerprintMap fingerprintMap = j.jenkins.getFingerprintMap();
         DefaultArtifactFileManager artifactFileManager = new DefaultArtifactFileManager(fingerprintMap, run, launcher, listener);
         try {
-            artifactFileManager.retrieveArtifact("signed.exe");
+            artifactFileManager.retrieveArtifact(SIGNED_ARTIFACT_PATH);
             fail("Expected ArtifactNotFoundException: signed artifact should not be stored automatically by submitSigningRequest");
         } catch (ArtifactNotFoundException expected) {
             // correct behavior - customer must use getSignedArtifact step explicitly
@@ -706,7 +709,7 @@ public class SubmitSigningRequestStepEndToEndTest {
         wireMockRule.verify(postRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests/SubmitWithoutArtifact"))
                 .withHeader("Authorization", equalTo("Bearer " + apiToken + ":" + trustedBuildSystemToken))
                 .withRequestBodyPart(aMultipart().withName("unsignedArtifactMetadata.sha256Hash").withBody(equalTo(sha256Hex)).build())
-                .withRequestBodyPart(aMultipart().withName("unsignedArtifactMetadata.fileName").withBody(equalTo("unsigned.exe")).build())
+                .withRequestBodyPart(aMultipart().withName("unsignedArtifactMetadata.fileName").withBody(equalTo(UNSIGNED_ARTIFACT_PATH)).build())
                 .withRequestBodyPart(aMultipart().withBody(equalTo(projectSlug)).build())
                 .withRequestBodyPart(aMultipart().withBody(equalTo(signingPolicySlug)).build())
                 .withRequestBodyPart(aMultipart().withBody(equalTo(remoteUrl)).build()));
@@ -732,7 +735,7 @@ public class SubmitSigningRequestStepEndToEndTest {
         wireMockRule.verify(postRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests/SubmitWithoutArtifact"))
                 .withHeader("Authorization", equalTo("Bearer " + apiToken + ":" + trustedBuildSystemToken))
                 .withRequestBodyPart(aMultipart().withName("unsignedArtifactMetadata.sha256Hash").withBody(equalTo(sha256Hex)).build())
-                .withRequestBodyPart(aMultipart().withName("unsignedArtifactMetadata.fileName").withBody(equalTo("unsigned.exe")).build())
+                .withRequestBodyPart(aMultipart().withName("unsignedArtifactMetadata.fileName").withBody(equalTo(UNSIGNED_ARTIFACT_PATH)).build())
                 .withRequestBodyPart(aMultipart().withBody(equalTo(projectSlug)).build())
                 .withRequestBodyPart(aMultipart().withBody(equalTo(signingPolicySlug)).build())
                 .withRequestBodyPart(aMultipart().withBody(equalTo(remoteUrl)).build())
@@ -756,7 +759,7 @@ public class SubmitSigningRequestStepEndToEndTest {
 
         wireMockRule.verify(postRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests/SubmitWithArtifactRetrievalLink"))
                 .withHeader("Authorization", equalTo("Bearer " + apiToken + ":" + trustedBuildSystemToken))
-                .withRequestBodyPart(aMultipart().withName("ArtifactRetrievalLink.FileName").withBody(equalTo("unsigned.exe")).build())
+                .withRequestBodyPart(aMultipart().withName("ArtifactRetrievalLink.FileName").withBody(equalTo(UNSIGNED_ARTIFACT_PATH)).build())
                 .withRequestBodyPart(aMultipart().withName("ArtifactRetrievalLink.Sha256Hash").withBody(equalTo(sha256Hex)).build())
                 .withRequestBodyPart(aMultipart().withName("ArtifactRetrievalLink.Url").withBody(equalTo(retrievalUrl)).build())
                 .withRequestBodyPart(aMultipart().withName("ArtifactRetrievalLink.HttpHeaders[0].Key").withBody(equalTo(retrievalHeaderName)).build())

--- a/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
@@ -48,7 +48,6 @@ public class SubmitSigningRequestStepEndToEndTest {
 
     @Theory
     public void submitSigningRequest(@FromDataPoints("allBooleans") boolean withOptionalFields) throws Exception {
-        byte[] signedArtifactBytes = Some.bytes();
         String trustedBuildSystemTokenCredentialId = Some.stringNonEmpty();
         String trustedBuildSystemToken = Some.stringNonEmpty();
         String unsignedArtifactString = Some.stringNonEmpty();
@@ -73,14 +72,14 @@ public class SubmitSigningRequestStepEndToEndTest {
 
         stubSubmitWithoutArtifact(organizationId, signingRequestId, getMockUrl(uploadPath.substring(1)));
         stubUploadUnsignedArtifact(uploadPath);
-        stubGetSigningRequestCompleted(organizationId, signingRequestId, signedArtifactBytes);
+        stubGetSigningRequestStatus(organizationId, signingRequestId);
 
         SignPathPluginGlobalConfiguration globalConfig = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
         globalConfig.setApiURL(apiUrl);
         globalConfig.setTrustedBuildSystemCredentialId(trustedBuildSystemTokenCredentialId);
         WorkflowJob workflowJob = withOptionalFields
-                ? createWorkflowJobWithOptionalParameters(apiUrl, trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, userDefinedParamName, userDefinedParamValue, true)
-                : createWorkflowJob(apiUrl, trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, true);
+                ? createWorkflowJobWithOptionalParameters(trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, userDefinedParamName, userDefinedParamValue, true)
+                : createWorkflowJob(trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, true);
 
         String remoteUrl = Some.url();
         BuildData buildData = new BuildData(Some.stringNonEmpty());
@@ -98,9 +97,13 @@ public class SubmitSigningRequestStepEndToEndTest {
             fail();
         }
 
-        byte[] signedArtifactContent = getSignedArtifactBytes(run);
-        assertArrayEquals(signedArtifactBytes, signedArtifactContent);
         assertTrue(run.getLog().contains("<returnValue>:\"" + signingRequestId + "\""));
+
+        // Signed artifact must NOT be archived automatically on Jenkins
+        assertSignedArtifactNotArchived(run);
+
+        // Status endpoint must have been polled (waitForCompletion was true)
+        wireMockRule.verify(getRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId + "/Status")));
 
         if (withOptionalFields) {
             assertSubmitWithoutArtifactRequest(apiToken, trustedBuildSystemToken, unsignedArtifactString,
@@ -147,8 +150,8 @@ public class SubmitSigningRequestStepEndToEndTest {
         globalConfig.setTrustedBuildSystemCredentialId(trustedBuildSystemTokenCredentialId);
 
         WorkflowJob workflowJob = withOptionalFields
-                ? createWorkflowJobWithOptionalParameters(apiUrl, trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, userDefinedParamName, userDefinedParamValue, false)
-                : createWorkflowJob(apiUrl, trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, false);
+                ? createWorkflowJobWithOptionalParameters(trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, artifactConfigurationSlug, description, userDefinedParamName, userDefinedParamValue, false)
+                : createWorkflowJob(trustedBuildSystemTokenCredentialId, apiTokenCredentialId, organizationId, projectSlug, signingPolicySlug, unsignedArtifactString, false);
 
         String remoteUrl = Some.url();
         BuildData buildData = new BuildData(Some.stringNonEmpty());
@@ -178,6 +181,8 @@ public class SubmitSigningRequestStepEndToEndTest {
         }
         assertUploadRequest(uploadPath, unsignedArtifactString);
         wireMockRule.verify(exactly(0), postRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests")));
+        // Status endpoint must NOT have been polled (waitForCompletion was false)
+        wireMockRule.verify(exactly(0), getRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId + "/Status")));
     }
 
     @Theory
@@ -205,7 +210,7 @@ public class SubmitSigningRequestStepEndToEndTest {
         globalConfig.setApiURL(apiUrl);
         globalConfig.setTrustedBuildSystemCredentialId(trustedBuildSystemTokenCredentialId);
 
-        WorkflowJob workflowJob = createWorkflowJob(apiUrl, trustedBuildSystemTokenCredentialId, apiTokenCredentialId,
+        WorkflowJob workflowJob = createWorkflowJob(trustedBuildSystemTokenCredentialId, apiTokenCredentialId,
                 organizationId, Some.stringNonEmpty(), Some.stringNonEmpty(), unsignedArtifactString, false);
 
         BuildData buildData = new BuildData(Some.stringNonEmpty());
@@ -253,7 +258,6 @@ public class SubmitSigningRequestStepEndToEndTest {
 
     @Theory
     public void submitSigningRequest_withArtifactRetrievalUrl(@FromDataPoints("allBooleans") boolean waitForCompletion) throws Exception {
-        byte[] signedArtifactBytes = Some.bytes();
         String trustedBuildSystemTokenCredentialId = Some.stringNonEmpty();
         String trustedBuildSystemToken = Some.stringNonEmpty();
         String unsignedArtifactString = Some.stringNonEmpty();
@@ -276,7 +280,7 @@ public class SubmitSigningRequestStepEndToEndTest {
 
         stubSubmitWithArtifactRetrievalLink(organizationId, signingRequestId);
         if (waitForCompletion) {
-            stubGetSigningRequestCompleted(organizationId, signingRequestId, signedArtifactBytes);
+            stubGetSigningRequestStatus(organizationId, signingRequestId);
         }
 
         SignPathPluginGlobalConfiguration globalConfig = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
@@ -284,7 +288,7 @@ public class SubmitSigningRequestStepEndToEndTest {
         globalConfig.setTrustedBuildSystemCredentialId(trustedBuildSystemTokenCredentialId);
 
         WorkflowJob workflowJob = createWorkflowJobWithArtifactRetrievalUrl(
-                apiUrl, trustedBuildSystemTokenCredentialId, apiTokenCredentialId,
+                trustedBuildSystemTokenCredentialId, apiTokenCredentialId,
                 organizationId, projectSlug, signingPolicySlug, unsignedArtifactString,
                 retrievalUrl, retrievalHeaderName, retrievalHeaderValue, waitForCompletion);
 
@@ -307,8 +311,9 @@ public class SubmitSigningRequestStepEndToEndTest {
         assertTrue(run.getLog().contains("<returnValue>:\"" + signingRequestId + "\""));
 
         if (waitForCompletion) {
-            byte[] signedArtifactContent = getSignedArtifactBytes(run);
-            assertArrayEquals(signedArtifactBytes, signedArtifactContent);
+            // Signed artifact must NOT be archived automatically - customer uses getSignedArtifact step
+            assertSignedArtifactNotArchived(run);
+            wireMockRule.verify(getRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId + "/Status")));
         }
 
         String sha256Hex = DigestUtils.sha256Hex(unsignedArtifactString.getBytes(StandardCharsets.UTF_8));
@@ -326,6 +331,10 @@ public class SubmitSigningRequestStepEndToEndTest {
 
     @Theory
     public void submitSigningRequest_withRetrievalHttpHeadersButNoUrl_fails() throws Exception {
+        SignPathPluginGlobalConfiguration globalConfig = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
+        globalConfig.setApiURL(getMockUrl());
+        globalConfig.setTrustedBuildSystemCredentialId(Some.stringNonEmpty());
+
         WorkflowJob workflowJob = j.createWorkflow("SignPath",
                 "writeFile text: 'content', file: 'unsigned.exe'; " +
                         "submitSigningRequest(" +
@@ -353,6 +362,9 @@ public class SubmitSigningRequestStepEndToEndTest {
 
     @Theory
     public void submitSigningRequest_withMissingField_fails() throws Exception {
+        SignPathPluginGlobalConfiguration globalConfig = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
+        globalConfig.setApiURL(getMockUrl());
+
         WorkflowJob workflowJob = j.createWorkflow("SignPath", "submitSigningRequest();");
 
         BuildData buildData = new BuildData(Some.stringNonEmpty());
@@ -367,6 +379,36 @@ public class SubmitSigningRequestStepEndToEndTest {
         // ASSERT
         assertEquals(Result.FAILURE, run.getResult());
         assertTrue(run.getLog().contains("SignPathStepInvalidArgumentException"));
+    }
+
+    @Theory
+    public void submitSigningRequest_withApiUrlParam_fails() throws Exception {
+        SignPathPluginGlobalConfiguration globalConfig = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
+        globalConfig.setApiURL(getMockUrl());
+        globalConfig.setTrustedBuildSystemCredentialId(Some.stringNonEmpty());
+
+        WorkflowJob workflowJob = j.createWorkflow("SignPath",
+                "writeFile text: 'content', file: 'unsigned.exe'; " +
+                        "submitSigningRequest(" +
+                        "apiUrl: '" + getMockUrl() + "'," +
+                        "inputArtifactPath: 'unsigned.exe'," +
+                        "trustedBuildSystemTokenCredentialId: '" + Some.stringNonEmpty() + "'," +
+                        "apiTokenCredentialId: '" + Some.stringNonEmpty() + "'," +
+                        "organizationId: '" + Some.uuid() + "'," +
+                        "projectSlug: '" + Some.stringNonEmpty() + "'," +
+                        "signingPolicySlug: '" + Some.stringNonEmpty() + "');");
+
+        BuildData buildData = new BuildData(Some.stringNonEmpty());
+        buildData.saveBuild(BuildDataDomainObjectMother.createRandomBuild(1));
+        buildData.addRemoteUrl(Some.url());
+
+        // ACT
+        QueueTaskFuture<WorkflowRun> runFuture = workflowJob.scheduleBuild2(0, buildData);
+        assert runFuture != null;
+        WorkflowRun run = runFuture.get();
+
+        // ASSERT - apiUrl is no longer a valid parameter; the step should fail
+        assertEquals(Result.FAILURE, run.getResult());
     }
 
     @DataPoints("allInvalidRootUrls")
@@ -384,7 +426,7 @@ public class SubmitSigningRequestStepEndToEndTest {
         globalConfig.setApiURL(mockUrl);
         globalConfig.setTrustedBuildSystemCredentialId(tbsToken);
 
-        WorkflowJob workflowJob = createWorkflowJob(mockUrl, tbsToken, Some.stringNonEmpty(), organizationId, Some.stringNonEmpty(), Some.stringNonEmpty(), Some.stringNonEmpty(), false);
+        WorkflowJob workflowJob = createWorkflowJob(tbsToken, Some.stringNonEmpty(), organizationId, Some.stringNonEmpty(), Some.stringNonEmpty(), Some.stringNonEmpty(), false);
 
         BuildData buildData = new BuildData(Some.stringNonEmpty());
         buildData.saveBuild(BuildDataDomainObjectMother.createRandomBuild(1));
@@ -427,29 +469,16 @@ public class SubmitSigningRequestStepEndToEndTest {
                 .willReturn(aResponse().withStatus(202)));
     }
 
-    private void stubGetSigningRequestCompleted(String organizationId, String signingRequestId, byte[] signedArtifactBytes) {
-        String downloadSignedArtifact = "downloadSignedArtifact";
-
+    private void stubGetSigningRequestStatus(String organizationId, String signingRequestId) {
         wireMockRule.stubFor(get(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId + "/Status"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withBody("{status: 'Completed', workflowStatus: 'Completed', isFinalStatus: true}")));
-
-        wireMockRule.stubFor(get(urlEqualTo("/" + downloadSignedArtifact))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withBody(signedArtifactBytes)));
-
-        wireMockRule.stubFor(get(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId + "/SignedArtifact"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withBody(signedArtifactBytes)));
     }
 
     // ---- Pipeline builders ----
 
-    private WorkflowJob createWorkflowJobWithOptionalParameters(String apiUrl,
-                                                                String trustedBuildSystemTokenCredentialId,
+    private WorkflowJob createWorkflowJobWithOptionalParameters(String trustedBuildSystemTokenCredentialId,
                                                                 String apiTokenCredentialId,
                                                                 String organizationId,
                                                                 String projectSlug,
@@ -462,9 +491,8 @@ public class SubmitSigningRequestStepEndToEndTest {
                                                                 boolean waitForCompletion) throws IOException {
         return j.createWorkflow("SignPath",
                 "writeFile text: '" + unsignedArtifactString + "', file: 'unsigned.exe'; " +
-                        "echo '<returnValue>:\"'+ submitSigningRequest( apiUrl: '" + apiUrl + "', " +
+                        "echo '<returnValue>:\"'+ submitSigningRequest(" +
                         "inputArtifactPath: 'unsigned.exe', " +
-                        "outputArtifactPath: 'signed.exe', " +
                         "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
                         "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
@@ -479,23 +507,17 @@ public class SubmitSigningRequestStepEndToEndTest {
                         "waitForCompletionTimeoutInSeconds: 10) + '\"';");
     }
 
-    private WorkflowJob createWorkflowJob(String apiUrl,
-                                          String trustedBuildSystemTokenCredentialId,
+    private WorkflowJob createWorkflowJob(String trustedBuildSystemTokenCredentialId,
                                           String apiTokenCredentialId,
                                           String organizationId,
                                           String projectSlug,
                                           String signingPolicySlug,
                                           String unsignedArtifactString,
                                           boolean waitForCompletion) throws IOException {
-        String outputArtifactPath = waitForCompletion
-                ? "outputArtifactPath: 'signed.exe', "
-                : "";
-
         return j.createWorkflow("SignPath",
                 "writeFile text: '" + unsignedArtifactString + "', file: 'unsigned.exe'; " +
-                        "echo '<returnValue>:\"'+ submitSigningRequest(apiUrl: '" + apiUrl + "', " +
+                        "echo '<returnValue>:\"'+ submitSigningRequest(" +
                         "inputArtifactPath: 'unsigned.exe', " +
-                        outputArtifactPath +
                         "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
                         "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
@@ -507,8 +529,7 @@ public class SubmitSigningRequestStepEndToEndTest {
                         "waitForCompletionTimeoutInSeconds: 10) + '\"';");
     }
 
-    private WorkflowJob createWorkflowJobWithArtifactRetrievalUrl(String apiUrl,
-                                                                   String trustedBuildSystemTokenCredentialId,
+    private WorkflowJob createWorkflowJobWithArtifactRetrievalUrl(String trustedBuildSystemTokenCredentialId,
                                                                    String apiTokenCredentialId,
                                                                    String organizationId,
                                                                    String projectSlug,
@@ -518,13 +539,10 @@ public class SubmitSigningRequestStepEndToEndTest {
                                                                    String retrievalHeaderName,
                                                                    String retrievalHeaderValue,
                                                                    boolean waitForCompletion) throws IOException {
-        String outputArtifactPath = waitForCompletion ? "outputArtifactPath: 'signed.exe', " : "";
-
         return j.createWorkflow("SignPath",
                 "writeFile text: '" + unsignedArtifactString + "', file: 'unsigned.exe'; " +
-                        "echo '<returnValue>:\"'+ submitSigningRequest(apiUrl: '" + apiUrl + "', " +
+                        "echo '<returnValue>:\"'+ submitSigningRequest(" +
                         "inputArtifactPath: 'unsigned.exe', " +
-                        outputArtifactPath +
                         "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
                         "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
                         "organizationId: '" + organizationId + "'," +
@@ -539,6 +557,19 @@ public class SubmitSigningRequestStepEndToEndTest {
     }
 
     // ---- Assertions ----
+
+    private void assertSignedArtifactNotArchived(WorkflowRun run) throws IOException {
+        Launcher launcher = j.createLocalLauncher();
+        TaskListener listener = j.createTaskListener();
+        FingerprintMap fingerprintMap = j.jenkins.getFingerprintMap();
+        DefaultArtifactFileManager artifactFileManager = new DefaultArtifactFileManager(fingerprintMap, run, launcher, listener);
+        try {
+            artifactFileManager.retrieveArtifact("signed.exe");
+            fail("Expected ArtifactNotFoundException: signed artifact should not be stored automatically by submitSigningRequest");
+        } catch (ArtifactNotFoundException expected) {
+            // correct behavior - customer must use getSignedArtifact step explicitly
+        }
+    }
 
     private void assertSubmitWithoutArtifactRequest(
             String apiToken,
@@ -645,15 +676,6 @@ public class SubmitSigningRequestStepEndToEndTest {
 
     private String getMockUrl(String postfix) {
         return String.format("http://localhost:%d/%s", MockServerPort, postfix);
-    }
-
-    private byte[] getSignedArtifactBytes(WorkflowRun run) throws IOException, ArtifactNotFoundException {
-        Launcher launcher = j.createLocalLauncher();
-        TaskListener listener = j.createTaskListener();
-        FingerprintMap fingerprintMap = j.jenkins.getFingerprintMap();
-        DefaultArtifactFileManager artifactFileManager = new DefaultArtifactFileManager(fingerprintMap, run, launcher, listener);
-        TemporaryFile signedArtifact = artifactFileManager.retrieveArtifact("signed.exe");
-        return TemporaryFileUtil.getContentAndDispose(signedArtifact);
     }
 
     @DataPoints("allBooleans")

--- a/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.FingerprintMap;
 import hudson.model.Result;
@@ -28,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.apache.commons.codec.digest.DigestUtils;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Base64;
@@ -182,7 +184,7 @@ public class SubmitSigningRequestStepEndToEndTest {
         assertTrue(run.getLog().contains("<returnValue>:\"" + signingRequestId + "\""));
 
         // Signed artifact must be stored at the specified outputArtifactPath
-        byte[] actualSignedArtifactBytes = getSignedArtifactBytes(run);
+        byte[] actualSignedArtifactBytes = getSignedArtifactBytes(workflowJob);
         assertArrayEquals(signedArtifactBytes, actualSignedArtifactBytes);
 
         // Status and download endpoints must both have been called
@@ -669,13 +671,12 @@ public class SubmitSigningRequestStepEndToEndTest {
 
     // ---- Assertions ----
 
-    private byte[] getSignedArtifactBytes(WorkflowRun run) throws IOException, ArtifactNotFoundException {
-        Launcher launcher = j.createLocalLauncher();
-        TaskListener listener = j.createTaskListener();
-        FingerprintMap fingerprintMap = j.jenkins.getFingerprintMap();
-        DefaultArtifactFileManager artifactFileManager = new DefaultArtifactFileManager(fingerprintMap, run, launcher, listener);
-        TemporaryFile signedArtifact = artifactFileManager.retrieveArtifact("signed.exe");
-        return TemporaryFileUtil.getContentAndDispose(signedArtifact);
+    private byte[] getSignedArtifactBytes(WorkflowJob workflowJob) throws IOException, InterruptedException {
+        FilePath workspace = j.jenkins.getWorkspaceFor(workflowJob);
+        assert workspace != null;
+        try (InputStream in = workspace.child("signed.exe").read()) {
+            return in.readAllBytes();
+        }
     }
 
     private void assertSignedArtifactNotArchived(WorkflowRun run) throws IOException {

--- a/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
+++ b/src/test/java/io/jenkins/plugins/signpath/SubmitSigningRequestStepEndToEndTest.java
@@ -119,6 +119,78 @@ public class SubmitSigningRequestStepEndToEndTest {
     }
 
     @Theory
+    public void submitSigningRequest_withOutputArtifactPath() throws Exception {
+        byte[] signedArtifactBytes = Some.bytes();
+        String trustedBuildSystemTokenCredentialId = Some.stringNonEmpty();
+        String trustedBuildSystemToken = Some.stringNonEmpty();
+        String unsignedArtifactString = Some.stringNonEmpty();
+        String apiTokenCredentialId = Some.stringNonEmpty();
+        String apiToken = Some.stringNonEmpty();
+        String projectSlug = Some.stringNonEmpty();
+        String signingPolicySlug = Some.stringNonEmpty();
+        String organizationId = Some.uuid().toString();
+        String signingRequestId = Some.uuid().toString();
+
+        CredentialsStore credentialStore = CredentialStoreUtils.getCredentialStore(j.jenkins);
+        assert credentialStore != null;
+        CredentialStoreUtils.addCredentials(credentialStore, CredentialsScope.SYSTEM, trustedBuildSystemTokenCredentialId, trustedBuildSystemToken);
+        CredentialStoreUtils.addCredentials(credentialStore, CredentialsScope.SYSTEM, apiTokenCredentialId, apiToken);
+
+        String apiUrl = getMockUrl();
+        String uploadPath = "/v1/" + organizationId + "/SigningRequests/" + signingRequestId + "/UploadUnsignedArtifact";
+
+        stubSubmitWithoutArtifact(organizationId, signingRequestId, getMockUrl(uploadPath.substring(1)));
+        stubUploadUnsignedArtifact(uploadPath);
+        stubGetSigningRequestStatus(organizationId, signingRequestId);
+        stubGetSignedArtifact(organizationId, signingRequestId, signedArtifactBytes);
+
+        SignPathPluginGlobalConfiguration globalConfig = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
+        globalConfig.setApiURL(apiUrl);
+        globalConfig.setTrustedBuildSystemCredentialId(trustedBuildSystemTokenCredentialId);
+
+        WorkflowJob workflowJob = j.createWorkflow("SignPath",
+                "writeFile text: '" + unsignedArtifactString + "', file: 'unsigned.exe'; " +
+                        "echo '<returnValue>:\"'+ submitSigningRequest(" +
+                        "inputArtifactPath: 'unsigned.exe', " +
+                        "trustedBuildSystemTokenCredentialId: '" + trustedBuildSystemTokenCredentialId + "'," +
+                        "apiTokenCredentialId: '" + apiTokenCredentialId + "'," +
+                        "organizationId: '" + organizationId + "'," +
+                        "projectSlug: '" + projectSlug + "'," +
+                        "signingPolicySlug: '" + signingPolicySlug + "'," +
+                        "waitForCompletion: true," +
+                        "outputArtifactPath: 'signed.exe'," +
+                        "serviceUnavailableTimeoutInSeconds: 10," +
+                        "uploadAndDownloadRequestTimeoutInSeconds: 10," +
+                        "waitForCompletionTimeoutInSeconds: 10) + '\"';");
+
+        String remoteUrl = Some.url();
+        BuildData buildData = new BuildData(Some.stringNonEmpty());
+        buildData.saveBuild(BuildDataDomainObjectMother.createRandomBuild(1));
+        buildData.addRemoteUrl(remoteUrl);
+
+        // ACT
+        QueueTaskFuture<WorkflowRun> runFuture = workflowJob.scheduleBuild2(0, buildData);
+        assert runFuture != null;
+        WorkflowRun run = runFuture.get();
+
+        // ASSERT
+        if (run.getResult() != Result.SUCCESS) {
+            assertEquals("", run.getLog() + run.getResult());
+            fail();
+        }
+
+        assertTrue(run.getLog().contains("<returnValue>:\"" + signingRequestId + "\""));
+
+        // Signed artifact must be stored at the specified outputArtifactPath
+        byte[] actualSignedArtifactBytes = getSignedArtifactBytes(run);
+        assertArrayEquals(signedArtifactBytes, actualSignedArtifactBytes);
+
+        // Status and download endpoints must both have been called
+        wireMockRule.verify(getRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId + "/Status")));
+        wireMockRule.verify(getRequestedFor(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId + "/SignedArtifact")));
+    }
+
+    @Theory
     public void submitSigningRequest_withoutWaitForCompletion(@FromDataPoints("allBooleans") boolean withOptionalFields) throws Exception {
         String unsignedArtifactString = Some.stringNonEmpty();
         String trustedBuildSystemTokenCredentialId = Some.stringNonEmpty();
@@ -330,6 +402,38 @@ public class SubmitSigningRequestStepEndToEndTest {
     }
 
     @Theory
+    public void submitSigningRequest_withOutputArtifactPathButNoWaitForCompletion_fails() throws Exception {
+        SignPathPluginGlobalConfiguration globalConfig = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
+        globalConfig.setApiURL(getMockUrl());
+        globalConfig.setTrustedBuildSystemCredentialId(Some.stringNonEmpty());
+
+        WorkflowJob workflowJob = j.createWorkflow("SignPath",
+                "writeFile text: 'content', file: 'unsigned.exe'; " +
+                        "submitSigningRequest(" +
+                        "inputArtifactPath: 'unsigned.exe', " +
+                        "trustedBuildSystemTokenCredentialId: '" + Some.stringNonEmpty() + "'," +
+                        "apiTokenCredentialId: '" + Some.stringNonEmpty() + "'," +
+                        "organizationId: '" + Some.uuid() + "'," +
+                        "projectSlug: '" + Some.stringNonEmpty() + "'," +
+                        "signingPolicySlug: '" + Some.stringNonEmpty() + "'," +
+                        "waitForCompletion: false," +
+                        "outputArtifactPath: 'signed.exe');");
+
+        BuildData buildData = new BuildData(Some.stringNonEmpty());
+        buildData.saveBuild(BuildDataDomainObjectMother.createRandomBuild(1));
+        buildData.addRemoteUrl(Some.url());
+
+        // ACT
+        QueueTaskFuture<WorkflowRun> runFuture = workflowJob.scheduleBuild2(0, buildData);
+        assert runFuture != null;
+        WorkflowRun run = runFuture.get();
+
+        // ASSERT
+        assertEquals(Result.FAILURE, run.getResult());
+        assertTrue(run.getLog().contains("outputArtifactPath can only be set if waitForCompletion is true"));
+    }
+
+    @Theory
     public void submitSigningRequest_withRetrievalHttpHeadersButNoUrl_fails() throws Exception {
         SignPathPluginGlobalConfiguration globalConfig = GlobalConfiguration.all().get(SignPathPluginGlobalConfiguration.class);
         globalConfig.setApiURL(getMockUrl());
@@ -469,6 +573,13 @@ public class SubmitSigningRequestStepEndToEndTest {
                 .willReturn(aResponse().withStatus(202)));
     }
 
+    private void stubGetSignedArtifact(String organizationId, String signingRequestId, byte[] signedArtifactBytes) {
+        wireMockRule.stubFor(get(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId + "/SignedArtifact"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody(signedArtifactBytes)));
+    }
+
     private void stubGetSigningRequestStatus(String organizationId, String signingRequestId) {
         wireMockRule.stubFor(get(urlEqualTo("/v1/" + organizationId + "/SigningRequests/" + signingRequestId + "/Status"))
                 .willReturn(aResponse()
@@ -557,6 +668,15 @@ public class SubmitSigningRequestStepEndToEndTest {
     }
 
     // ---- Assertions ----
+
+    private byte[] getSignedArtifactBytes(WorkflowRun run) throws IOException, ArtifactNotFoundException {
+        Launcher launcher = j.createLocalLauncher();
+        TaskListener listener = j.createTaskListener();
+        FingerprintMap fingerprintMap = j.jenkins.getFingerprintMap();
+        DefaultArtifactFileManager artifactFileManager = new DefaultArtifactFileManager(fingerprintMap, run, launcher, listener);
+        TemporaryFile signedArtifact = artifactFileManager.retrieveArtifact("signed.exe");
+        return TemporaryFileUtil.getContentAndDispose(signedArtifact);
+    }
 
     private void assertSignedArtifactNotArchived(WorkflowRun run) throws IOException {
         Launcher launcher = j.createLocalLauncher();


### PR DESCRIPTION
**Jenkins Cleanup:**

- No longer archiving the signed artifact automatically
- Removed the deprecated `apiUrl` parameter

### Testing done

- end-to-end tests updated and passing

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed